### PR TITLE
Fixes multiple text state updates on clear

### DIFF
--- a/cosmoz-autocomplete.js
+++ b/cosmoz-autocomplete.js
@@ -48,7 +48,6 @@ const Autocomplete = ({
 		<paper-input
 			id="input"
 			.label=${label}
-			.value=${live(text)}
 			.errorMessage=${errorMessage}
 			invalid=${ifDefined(invalid)}
 			disabled=${ifDefined(disabled)}
@@ -57,6 +56,7 @@ const Autocomplete = ({
 			@input=${onEdit}
 			@value-changed=${onText}
 			@focused-changed=${onFocus}
+			.value=${live(text)}
 		>
 			<slot name="prefix" slot="prefix"></slot>
 			${!!value &&
@@ -73,12 +73,12 @@ const Autocomplete = ({
 		</paper-input>
 		${items.length
 		? html`
-					<cosmoz-suggestions
-						.items=${items}
-						.onSelect=${onSelect}
-						.textProperty=${textProperty}
-					/>
-			  `
+			<cosmoz-suggestions
+				.items=${items}
+				.onSelect=${onSelect}
+				.textProperty=${textProperty}
+			/>
+		 `
 		: nothing}
 	`;
 };

--- a/lib/use-autocomplete.js
+++ b/lib/use-autocomplete.js
@@ -3,63 +3,63 @@ import {
 } from 'haunted';
 import { propOrRoot } from './utils';
 
-export const useAutocomplete = ({
-	source,
-	textProperty,
-	onChange,
-	value: eValue
-}) => {
-	const [text, setText] = useState(),
-		[value, setValue] = useState(),
-		[focused, setFocused] = useState(false),
-		textProp = useCallback(o => propOrRoot(o, textProperty), [textProperty]);
+const EMPTY = [],
+	useAutocomplete = ({
+		source, textProperty, onChange, value: eValue
+	}) => {
+		const [text, setText] = useState(''),
+			[value, setValue] = useState(),
+			[focused, setFocused] = useState(false),
+			textProp = useCallback(o => propOrRoot(o, textProperty), [textProperty]);
 
-	useLayoutEffect(() => {
-		setValue(value);
-	}, [eValue, setValue]);
+		useLayoutEffect(() => {
+			setValue(value);
+		}, [eValue, setValue]);
 
-	return {
-		text,
-		focused,
-		value,
+		return {
+			text,
+			focused,
+			value,
 
-		clear: useCallback(() => {
-			setValue(undefined);
-			setText(undefined);
-			if (onChange) {
-				onChange();
-			}
-		}, [setText, setValue, onChange]),
-
-		items: useMemo(() => {
-			if (value || !focused) {
-				return [];
-			}
-			if (!text) {
-				return source;
-			}
-			const query = text.trim().toLowerCase();
-			if (!query) {
-				return source;
-			}
-			return source.filter(o =>
-				textProp(o)
-					.toLowerCase()
-					.includes(query)
-			);
-		}, [focused, source, textProp, text, value]),
-		onEdit: useCallback(() => setValue(undefined), [setValue]),
-		onText: useCallback(e => setText(e.target.value), [setValue]),
-		onFocus: useCallback(e => setFocused(e.target.focused), [setFocused]),
-		onSelect: useCallback(
-			o => {
-				setValue(o);
-				setText(textProp(o));
+			clear: useCallback(() => {
+				setValue(undefined);
+				setText('');
 				if (onChange) {
-					onChange(o);
+					onChange();
 				}
-			},
-			[setValue, setText, onChange, textProp]
-		)
+			}, [setText, setValue, onChange]),
+
+			items: useMemo(() => {
+				if (value || !focused) {
+					return EMPTY;
+				}
+				if (!text) {
+					return source;
+				}
+				const query = text.trim().toLowerCase();
+				if (!query) {
+					return source;
+				}
+				return source.filter(o =>
+					textProp(o)
+						.toLowerCase()
+						.includes(query)
+				);
+			}, [focused, source, textProp, text, value]),
+			onEdit: useCallback(() => setValue(undefined), [setValue]),
+			onText: useCallback(e => setText(e.target.value), [setValue]),
+			onFocus: useCallback(e => setFocused(e.target.focused), [setFocused]),
+			onSelect: useCallback(
+				o => {
+					setValue(o);
+					setText(textProp(o));
+					if (onChange) {
+						onChange(o);
+					}
+				},
+				[setValue, setText, onChange, textProp]
+			)
+		};
 	};
-};
+
+export { useAutocomplete };

--- a/lib/use-autocomplete.js
+++ b/lib/use-autocomplete.js
@@ -47,7 +47,13 @@ const EMPTY = [],
 				);
 			}, [focused, source, textProp, text, value]),
 			onEdit: useCallback(() => setValue(undefined), [setValue]),
-			onText: useCallback(e => setText(e.target.value), [setValue]),
+			onText: useCallback(e => {
+				const newText = e.target.value;
+				if (newText === text) {
+					return;
+				}
+				setText(newText);
+			}, [setText, text]),
 			onFocus: useCallback(e => setFocused(e.target.focused), [setFocused]),
 			onSelect: useCallback(
 				o => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1788,12 +1788,12 @@
 			}
 		},
 		"@octokit/endpoint": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.0.tgz",
-			"integrity": "sha512-3nx+MEYoZeD0uJ+7F/gvELLvQJzLXhep2Az0bBSXagbApDvDW0LWwpnAIY/hb0Jwe17A0fJdz0O12dPh05cj7A==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.1.tgz",
+			"integrity": "sha512-pOPHaSz57SFT/m3R5P8MUu4wLPszokn5pXcB/pzavLTQf2jbU+6iayTvzaY6/BiotuRS0qyEUkx3QglT4U958A==",
 			"dev": true,
 			"requires": {
-				"@octokit/types": "^2.0.0",
+				"@octokit/types": "^2.11.1",
 				"is-plain-object": "^3.0.0",
 				"universal-user-agent": "^5.0.0"
 			},
@@ -1853,24 +1853,24 @@
 			"dev": true
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.5.2.tgz",
-			"integrity": "sha512-i5GlEWm7k/SzBr7QrIOuas/1nNgr4JcmgM14TAKULVkv4L5mOY+pcVIUMU3qdYhFyblBFhigujav5seMnkqBnQ==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.7.1.tgz",
+			"integrity": "sha512-YOlcE3bbk2ohaOVdRj9ww7AUYfmnS9hwJJGSj3/rFlNfMGOId4G8dLlhghXpdNSn05H0FRoI94UlFUKnn30Cyw==",
 			"dev": true,
 			"requires": {
-				"@octokit/types": "^2.0.1",
+				"@octokit/types": "^2.11.1",
 				"deprecation": "^2.3.1"
 			}
 		},
 		"@octokit/request": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.0.tgz",
-			"integrity": "sha512-uAJO6GI8z8VHBqtY7VTL9iFy1Y+UTp5ShpI97tY5z0qBfYKE9rZCRsCm23VmF00x+IoNJ7a0nuVITs/+wS9/mg==",
+			"version": "5.4.2",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.2.tgz",
+			"integrity": "sha512-zKdnGuQ2TQ2vFk9VU8awFT4+EYf92Z/v3OlzRaSh4RIP0H6cvW1BFPXq4XYvNez+TPQjqN+0uSkCYnMFFhcFrw==",
 			"dev": true,
 			"requires": {
-				"@octokit/endpoint": "^6.0.0",
+				"@octokit/endpoint": "^6.0.1",
 				"@octokit/request-error": "^2.0.0",
-				"@octokit/types": "^2.8.2",
+				"@octokit/types": "^2.11.1",
 				"deprecation": "^2.0.0",
 				"is-plain-object": "^3.0.0",
 				"node-fetch": "^2.3.0",
@@ -1907,30 +1907,30 @@
 			}
 		},
 		"@octokit/rest": {
-			"version": "17.3.0",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.3.0.tgz",
-			"integrity": "sha512-zqvsnWUEldmF3sCmGGlQ2u+NDQMpF5O4gnwefnGt6yJcN6eGWDYJJvRD/wQ1/nALXU0XABhQElBgR/0wNoprsA==",
+			"version": "17.5.1",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.5.1.tgz",
+			"integrity": "sha512-0rGY7eo0cw8FYX7jAtUgfy3j+05zhs9JvkPFegx00HAaayodM1ixlHhCOB5yirGbsVOxbRIWVkvKc2yY9367gg==",
 			"dev": true,
 			"requires": {
 				"@octokit/core": "^2.4.3",
 				"@octokit/plugin-paginate-rest": "^2.1.0",
 				"@octokit/plugin-request-log": "^1.0.0",
-				"@octokit/plugin-rest-endpoint-methods": "3.5.2"
+				"@octokit/plugin-rest-endpoint-methods": "3.7.1"
 			}
 		},
 		"@octokit/types": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.10.0.tgz",
-			"integrity": "sha512-0/NN22MgQvNNgMjTwzWUzcIfFfks3faqiP1D1oQQz49KYeOWc+KkRG9ASbAPurrAnOaDiqnnuDYzhNT9cq4e8Q==",
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.11.1.tgz",
+			"integrity": "sha512-QaLoLkmFdfoNbk3eOzPv7vKrUY0nRJIYmZDoz/pTer4ICpqu80aSQTVHnnUxEFuURCiidig76CcxUOYC/bY3RQ==",
 			"dev": true,
 			"requires": {
 				"@types/node": ">= 8"
 			}
 		},
 		"@open-wc/building-utils": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/@open-wc/building-utils/-/building-utils-2.16.3.tgz",
-			"integrity": "sha512-lO/HD2wEl2avRSgqISeP4S1zPQEGRQ/+Zh8RBk9AggDma3uPiRU0RbuRvhunmu7hFWVDBj5o1FRJ7xJ94AWCnw==",
+			"version": "2.16.4",
+			"resolved": "https://registry.npmjs.org/@open-wc/building-utils/-/building-utils-2.16.4.tgz",
+			"integrity": "sha512-ByknIanbo2wSpNs7gHy/hBHmPOO91IOJCDravSNreK88XdTd4vnCkx0DrRltgwvPIg7GVHWv/NFfSfWecRrh4Q==",
 			"requires": {
 				"@babel/core": "^7.9.0",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.3",
@@ -1979,9 +1979,9 @@
 			}
 		},
 		"@open-wc/demoing-storybook": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@open-wc/demoing-storybook/-/demoing-storybook-2.0.2.tgz",
-			"integrity": "sha512-qgodNrsrNtCU9XP26fbjcUrTCdTvibq1ZYx5UpI9woyiKCYm0xzpsDSQWleY0vzqYH5yIIOp7DqdNrMee9o4gQ==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@open-wc/demoing-storybook/-/demoing-storybook-2.0.5.tgz",
+			"integrity": "sha512-YNevPg5QGashwHamqx3FLmMszJHDavquM0gRNw230ZJ9Q0CMmZaVaF6gK6HVpFjbybAjaEC0lc6RgRmxZx19Sg==",
 			"requires": {
 				"@babel/core": "^7.9.0",
 				"@babel/plugin-proposal-dynamic-import": "^7.8.3",
@@ -1989,8 +1989,8 @@
 				"@babel/plugin-transform-react-jsx": "^7.9.1",
 				"@babel/preset-env": "^7.9.0",
 				"@mdx-js/mdx": "^1.5.1",
-				"@open-wc/rollup-plugin-html": "^1.0.0",
-				"@open-wc/rollup-plugin-polyfills-loader": "^1.0.0",
+				"@open-wc/rollup-plugin-html": "^1.0.2",
+				"@open-wc/rollup-plugin-polyfills-loader": "^1.0.2",
 				"@rollup/plugin-node-resolve": "^7.1.1",
 				"@storybook/addon-docs": "5.3.1",
 				"babel-plugin-bundled-import-meta": "^0.3.2",
@@ -1998,7 +1998,7 @@
 				"command-line-args": "^5.0.2",
 				"command-line-usage": "^6.1.0",
 				"deepmerge": "^4.2.2",
-				"es-dev-server": "^1.46.2",
+				"es-dev-server": "^1.46.4",
 				"es-module-lexer": "^0.3.13",
 				"fs-extra": "^8.1.0",
 				"glob": "^7.1.3",
@@ -2007,21 +2007,21 @@
 				"rollup": "^2.0.0",
 				"rollup-plugin-babel": "^5.0.0-alpha.1",
 				"rollup-plugin-terser": "^5.2.0",
-				"storybook-addon-markdown-docs": "^0.2.6",
+				"storybook-addon-markdown-docs": "^0.2.7",
 				"storybook-prebuilt": "^1.5.0"
 			}
 		},
 		"@open-wc/karma-esm": {
-			"version": "2.13.23",
-			"resolved": "https://registry.npmjs.org/@open-wc/karma-esm/-/karma-esm-2.13.23.tgz",
-			"integrity": "sha512-UnC0Vy06F5doojitKIkG+UMbvJBqfRf6o5bdcXaOAd+7SpvpGRwmOq9+/4mkqzIKe/EIiTKc2SoCIh82JI0CTw==",
+			"version": "2.13.25",
+			"resolved": "https://registry.npmjs.org/@open-wc/karma-esm/-/karma-esm-2.13.25.tgz",
+			"integrity": "sha512-GzU4lwCLCiJ/4d/o3+r7Nw5XPMRv39eHCApN9ORZP9D30zf/KytaVbO8JkPmNLZHWVZ89HzLrTXxKn+tL95+zw==",
 			"dev": true,
 			"requires": {
-				"@open-wc/building-utils": "^2.16.3",
+				"@open-wc/building-utils": "^2.16.4",
 				"babel-plugin-istanbul": "^5.1.4",
 				"chokidar": "^3.0.0",
 				"deepmerge": "^4.2.2",
-				"es-dev-server": "^1.46.2",
+				"es-dev-server": "^1.46.4",
 				"minimatch": "^3.0.4",
 				"node-fetch": "^2.6.0",
 				"portfinder": "^1.0.21",
@@ -2029,11 +2029,11 @@
 			}
 		},
 		"@open-wc/rollup-plugin-html": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@open-wc/rollup-plugin-html/-/rollup-plugin-html-1.0.0.tgz",
-			"integrity": "sha512-tor8x2StEtn4lmvov7Dsg2NQUk9Oe0iBmW6IRnbtvEnkI+MLVznMV6PuNumoZL+43zMYgEMFpYny89cvPrP/yA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@open-wc/rollup-plugin-html/-/rollup-plugin-html-1.0.2.tgz",
+			"integrity": "sha512-8e7Uph2XLkT8m5cmI3ZhKT5jmdGVk0DCOwT90GNKQYHXdlL9GCgweI+l8rNKr/9DRIX31y8d+jkzAlcLVekiBw==",
 			"requires": {
-				"@open-wc/building-utils": "^2.16.3",
+				"@open-wc/building-utils": "^2.16.4",
 				"@types/html-minifier": "^3.5.3",
 				"fs-extra": "^8.1.0",
 				"html-minifier": "^4.0.0",
@@ -2042,29 +2042,29 @@
 			}
 		},
 		"@open-wc/rollup-plugin-polyfills-loader": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@open-wc/rollup-plugin-polyfills-loader/-/rollup-plugin-polyfills-loader-1.0.0.tgz",
-			"integrity": "sha512-eK4JBPrdZRAYj1uWOuK+WfBACU0CY7CQ8uJLH3NMljv/fnbs+Dy3oOSNiYl4DMWOuUWBgBGmeXaqYGbS5GvvVw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@open-wc/rollup-plugin-polyfills-loader/-/rollup-plugin-polyfills-loader-1.0.2.tgz",
+			"integrity": "sha512-4y4eXpO773TcAcZ06oXiLft+3taNk608++Ab6JRSnlKk3GcHXAlkNvwlSGKaTA05yczx9Pn5epU/Lmhp+bEhwQ==",
 			"requires": {
-				"@open-wc/rollup-plugin-html": "^1.0.0",
-				"polyfills-loader": "^1.5.4"
+				"@open-wc/rollup-plugin-html": "^1.0.2",
+				"polyfills-loader": "^1.5.5"
 			}
 		},
 		"@open-wc/semantic-dom-diff": {
-			"version": "0.17.7",
-			"resolved": "https://registry.npmjs.org/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.17.7.tgz",
-			"integrity": "sha512-7SyZLBoXxYMIq2mQh3kJ80a09+M+ZpOiobBpwbW/8TKZEoOriB+eWAej5yPj6bM/XvUfn4y725vyS58U+GBeSw==",
+			"version": "0.17.8",
+			"resolved": "https://registry.npmjs.org/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.17.8.tgz",
+			"integrity": "sha512-wYk9REynp75vgfH3gh1p0718K0wjiV04g+wjGtc+nzx+ChXRO9U2W7JTCniRBG8fAW2rBhzkS0GVQs8kLhjK6w==",
 			"dev": true
 		},
 		"@open-wc/testing": {
-			"version": "2.5.11",
-			"resolved": "https://registry.npmjs.org/@open-wc/testing/-/testing-2.5.11.tgz",
-			"integrity": "sha512-QtLA5jGpfEJOoC0ka2OAqRAAZ0/pbgWPVLzgKPu//OC3CDxvVgKdEObW9pXVKpti5oLa7NRMxeJcTMkE4aO68Q==",
+			"version": "2.5.12",
+			"resolved": "https://registry.npmjs.org/@open-wc/testing/-/testing-2.5.12.tgz",
+			"integrity": "sha512-Z7sgrQkL1JaDOehwr/1Uaoytd5PcIHux+7IIh/gTvTapi9emqJc9n252huvZ4Mle52XKBPPfMlWwIWR6ailPFw==",
 			"dev": true,
 			"requires": {
 				"@open-wc/chai-dom-equals": "^0.12.36",
-				"@open-wc/semantic-dom-diff": "^0.17.7",
-				"@open-wc/testing-helpers": "^1.7.1",
+				"@open-wc/semantic-dom-diff": "^0.17.8",
+				"@open-wc/testing-helpers": "^1.7.2",
 				"@types/chai": "^4.1.7",
 				"@types/chai-dom": "^0.0.9",
 				"@types/mocha": "^5.0.0",
@@ -2077,18 +2077,18 @@
 			}
 		},
 		"@open-wc/testing-helpers": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@open-wc/testing-helpers/-/testing-helpers-1.7.1.tgz",
-			"integrity": "sha512-v7AYqIGA50mFfwuZNqCxB0ZWI+aioZtiprBMl5bZT4eRMRz876jRMiX9y327RwwisGie6+HDIJHwhWjrd1GdOA==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/@open-wc/testing-helpers/-/testing-helpers-1.7.2.tgz",
+			"integrity": "sha512-ilUdoObOTu9IO8cbv7MiLGEpmoIl6+31OFblOfq7UseqL8+KId88spqhUFc3UToX429HHypsUVuKHFfEST3oXw==",
 			"dev": true
 		},
 		"@open-wc/testing-karma": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/@open-wc/testing-karma/-/testing-karma-3.3.12.tgz",
-			"integrity": "sha512-Hl0VGwBUQKuyuDrtr2dLi1SdD/BbkImuuE/Ieui37RyRevZy+QH97dIHvHLOSyrCqzaEzV9ePvxiPc7lEHnYIQ==",
+			"version": "3.3.14",
+			"resolved": "https://registry.npmjs.org/@open-wc/testing-karma/-/testing-karma-3.3.14.tgz",
+			"integrity": "sha512-6aQ/1QYR2+Zjat3LStPG/rrhsiPCpxc3Shzrk3coK//mFO/2KldBDi3QeQVS+mEQloA5S+izLtrSTHKWh+q+lg==",
 			"dev": true,
 			"requires": {
-				"@open-wc/karma-esm": "^2.13.23",
+				"@open-wc/karma-esm": "^2.13.25",
 				"axe-core": "^3.3.1",
 				"karma": "^4.1.0",
 				"karma-chrome-launcher": "^3.1.0",
@@ -2755,6 +2755,12 @@
 					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 					"dev": true
 				},
+				"normalize-url": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.0.0.tgz",
+					"integrity": "sha512-bAEm2fx8Dq/a35Z6PIRkkBBJvR56BbEJvhpNtvCZ4W9FyORSna77fn+xtYFjqk5JpBS+fMnAOG/wFgkQBmB7hw==",
+					"dev": true
+				},
 				"npm-run-path": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -3374,9 +3380,9 @@
 			}
 		},
 		"@tootallnate/once": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.0.0.tgz",
-			"integrity": "sha512-KYyTT/T6ALPkIRd2Ge080X/BsXvy9O0hcWTtMWkPvwAwF99+vn6Dv4GzrFT/Nn1LePr+FFDbRXXlqmsy9lw2zA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.1.tgz",
+			"integrity": "sha512-8foiU77JL9wR2yPZwecqN2YdJp/olC4CBVEaHdWWlz5rMQZcVEA3aXxlbfbUACVVxVwtTle3eYSnpBeKvIYcIg==",
 			"dev": true
 		},
 		"@types/babel-types": {
@@ -3480,9 +3486,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.11.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
-			"integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g=="
+			"version": "13.13.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.1.tgz",
+			"integrity": "sha512-uysqysLJ+As9jqI5yqjwP3QJrhOcUwBjHUlUxPxjbplwKoILvXVsmYWEhfmAQlrPfbRZmhJB007o4L9sKqtHqQ=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
@@ -3728,9 +3734,9 @@
 			}
 		},
 		"ajv": {
-			"version": "6.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-			"integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+			"version": "6.12.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+			"integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
@@ -4045,9 +4051,9 @@
 			}
 		},
 		"babel-plugin-dynamic-import-node": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
-			"integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.2.tgz",
+			"integrity": "sha512-yvczAMjbc73xira9yTyF1XnEmkX8QwlUhmxuhimeMUeAaA6s7busTPRVDzhVG7eeBdNcRiZ/mAwFrJ9It4vQcg==",
 			"requires": {
 				"object.assign": "^4.1.0"
 			}
@@ -4436,12 +4442,12 @@
 			"dev": true
 		},
 		"browserslist": {
-			"version": "4.11.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.1.tgz",
-			"integrity": "sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.0.tgz",
+			"integrity": "sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==",
 			"requires": {
-				"caniuse-lite": "^1.0.30001038",
-				"electron-to-chromium": "^1.3.390",
+				"caniuse-lite": "^1.0.30001043",
+				"electron-to-chromium": "^1.3.413",
 				"node-releases": "^1.1.53",
 				"pkg-up": "^2.0.0"
 			}
@@ -4625,9 +4631,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001042",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001042.tgz",
-			"integrity": "sha512-igMQ4dlqnf4tWv0xjaaE02op9AJ2oQzXKjWf4EuAHFN694Uo9/EfPVIPJcmn2WkU9RqozCxx5e2KPcVClHDbDw=="
+			"version": "1.0.30001045",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001045.tgz",
+			"integrity": "sha512-Y8o2Iz1KPcD6FjySbk1sPpvJqchgxk/iow0DABpGyzA1UeQAuxh63Xh0Enj5/BrsYbXtCN32JmR4ZxQTCQ6E6A=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",
@@ -5665,9 +5671,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.412",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.412.tgz",
-			"integrity": "sha512-4bVdSeJScR8fT7ERveLWbxemY5uXEHVseqMRyORosiKcTUSGtVwBkV8uLjXCqoFLeImA57Z9hbz3TOid01U4Hw=="
+			"version": "1.3.414",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.414.tgz",
+			"integrity": "sha512-UfxhIvED++qLwWrAq9uYVcqF8FdeV9sU2S7qhiHYFODxzXRrd1GZRl/PjITHsTEejgibcWDraD8TQqoHb1aCBQ=="
 		},
 		"emoji-regex": {
 			"version": "6.1.1",
@@ -5941,9 +5947,9 @@
 			}
 		},
 		"es-dev-server": {
-			"version": "1.46.2",
-			"resolved": "https://registry.npmjs.org/es-dev-server/-/es-dev-server-1.46.2.tgz",
-			"integrity": "sha512-pqJ1bejSEbcxXFcMi4egkLaLWg5ASaxNeSRiGS9vpxu3S5f0aWX8XgYwifT6VeBpEHalkwb10prm/nvDCZKQlw==",
+			"version": "1.46.4",
+			"resolved": "https://registry.npmjs.org/es-dev-server/-/es-dev-server-1.46.4.tgz",
+			"integrity": "sha512-8K9CSbKMT+nntN7kW1UHn4tT3AkB3vXxQVw74CudOBtUsyTWbSdMMaRKpfp3BqVumbeJeGF1LTsb7OejtZJOug==",
 			"requires": {
 				"@babel/core": "^7.9.0",
 				"@babel/plugin-proposal-dynamic-import": "^7.8.3",
@@ -5956,7 +5962,7 @@
 				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
 				"@babel/plugin-transform-template-literals": "^7.8.3",
 				"@babel/preset-env": "^7.9.0",
-				"@open-wc/building-utils": "^2.16.3",
+				"@open-wc/building-utils": "^2.16.4",
 				"@rollup/plugin-node-resolve": "^7.1.1",
 				"@rollup/pluginutils": "^3.0.0",
 				"@types/minimatch": "^3.0.3",
@@ -5984,7 +5990,7 @@
 				"opn": "^5.4.0",
 				"parse5": "^5.1.1",
 				"path-is-inside": "^1.0.2",
-				"polyfills-loader": "^1.5.4",
+				"polyfills-loader": "^1.5.5",
 				"portfinder": "^1.0.21",
 				"strip-ansi": "^5.2.0",
 				"systemjs": "^4.0.0",
@@ -8097,6 +8103,14 @@
 			"requires": {
 				"from2": "^2.3.0",
 				"p-is-promise": "^3.0.0"
+			},
+			"dependencies": {
+				"p-is-promise": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+					"integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
+					"dev": true
+				}
 			}
 		},
 		"invariant": {
@@ -9639,9 +9653,9 @@
 			}
 		},
 		"jszip": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.3.0.tgz",
-			"integrity": "sha512-EJ9k766htB1ZWnsV5ZMDkKLgA+201r/ouFF8R2OigVjVdcm2rurcBrrdXaeqBJbqnUVMko512PYmlncBKE1Huw==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.4.0.tgz",
+			"integrity": "sha512-gZAOYuPl4EhPTXT0GjhI3o+ZAz3su6EhLrKUoAivcKqyqC7laS5JEv4XWZND9BgcDcF83vI85yGbDmDR6UhrIg==",
 			"dev": true,
 			"requires": {
 				"lie": "~3.3.0",
@@ -10781,12 +10795,6 @@
 					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
 					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 					"dev": true
-				},
-				"p-is-promise": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-					"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
-					"dev": true
 				}
 			}
 		},
@@ -11287,9 +11295,9 @@
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 		},
 		"normalize-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.0.0.tgz",
-			"integrity": "sha512-bAEm2fx8Dq/a35Z6PIRkkBBJvR56BbEJvhpNtvCZ4W9FyORSna77fn+xtYFjqk5JpBS+fMnAOG/wFgkQBmB7hw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+			"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
 			"dev": true
 		},
 		"npm": {
@@ -15092,9 +15100,9 @@
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-is-promise": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
-			"integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
 			"dev": true
 		},
 		"p-limit": {
@@ -15210,14 +15218,6 @@
 				"normalize-url": "^3.3.0",
 				"parse-path": "^4.0.0",
 				"protocols": "^1.4.0"
-			},
-			"dependencies": {
-				"normalize-url": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-					"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
-					"dev": true
-				}
 			}
 		},
 		"parse5": {
@@ -15437,20 +15437,20 @@
 			}
 		},
 		"polished": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/polished/-/polished-3.5.1.tgz",
-			"integrity": "sha512-GVbvskpBiDV5TknurGL6OyFfLHsCknxbU8w5iMppT8rW0tLEoQHrIRfrPNPqGXNj3HGhkjRvhmg59Fy7HSnCAw==",
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/polished/-/polished-3.5.2.tgz",
+			"integrity": "sha512-vWoRDg3gY5RQBtUfcj9MRN10VCIf4EkdUikGxyXItg2Hnwk+eIVtdBiLajN0ldFeT3Vq4r/QNbjrQdhqBKrTug==",
 			"requires": {
 				"@babel/runtime": "^7.8.7"
 			}
 		},
 		"polyfills-loader": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/polyfills-loader/-/polyfills-loader-1.5.4.tgz",
-			"integrity": "sha512-Jttph/AKpsmtw5+HGeCqZYaKTYZ3WswVgnTuSzUZOpChSETXiYQ1eihMiTfPIoD9FpIsTb7Ow0VHTFChBvzw9g==",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/polyfills-loader/-/polyfills-loader-1.5.5.tgz",
+			"integrity": "sha512-Rn+zv8e0OVVSEN8w8yhFmjyDoBGiGZQtzlHGm17HfCYjgzuMpnGME12g55ALDuCUfU1inqKtDiqc6XVsoGcpYA==",
 			"requires": {
 				"@babel/core": "^7.9.0",
-				"@open-wc/building-utils": "^2.16.3",
+				"@open-wc/building-utils": "^2.16.4",
 				"@webcomponents/webcomponentsjs": "^2.4.0",
 				"abortcontroller-polyfill": "^1.4.0",
 				"core-js-bundle": "^3.6.0",
@@ -16582,9 +16582,9 @@
 			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
 		},
 		"resolve": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.16.0.tgz",
-			"integrity": "sha512-LarL/PIKJvc09k1jaeT4kQb/8/7P+qV4qSnN2K80AES+OHdfZELAKVOBjxsvtToT/uLOfFbvYvKfZmV8cee7nA==",
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.16.1.tgz",
+			"integrity": "sha512-rmAglCSqWWMrrBv/XM6sW0NuRFiKViw/W4d9EbC4pt+49H8JwHy+mcGmALTEg504AUDcLTvb1T2q3E9AnmY+ig==",
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -17856,9 +17856,9 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.16",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-			"integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+			"version": "0.5.17",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.17.tgz",
+			"integrity": "sha512-bwdKOBZ5L0gFRh4KOxNap/J/MpvX9Yxsq9lFDx65s3o7F/NiHy7JRaGIS8MwW6tZPAq9UXE207Il0cfcb5yu/Q==",
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -17902,9 +17902,9 @@
 			}
 		},
 		"spdx-exceptions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
@@ -18021,9 +18021,9 @@
 			"integrity": "sha512-llZqXAXjG2E4FvWsZxFmBDfh6kqQuGFZm64TX23qW02Hf4dyElhDEbYx1IIVTEMKWrrDnDA9oqOjY8WHo2NgcA=="
 		},
 		"storybook-addon-markdown-docs": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/storybook-addon-markdown-docs/-/storybook-addon-markdown-docs-0.2.6.tgz",
-			"integrity": "sha512-MdOqhe5IgnkJS+sp2iqGzWL0wByRwAFVIH/YqV6qJ25WaGvXlt8t92841jDDuIz3+54otViibTu+8KcY4a7VtQ==",
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/storybook-addon-markdown-docs/-/storybook-addon-markdown-docs-0.2.7.tgz",
+			"integrity": "sha512-A2XmrohinbeyU3vz/81ji6pMa72GlKzqx0qM+zb7D5HUPQFlLt838ieOEWMMkKjtiJBOvWiMznKFvATV007AIg==",
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/core": "^7.9.0",
@@ -19097,9 +19097,9 @@
 			"integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
 		},
 		"vue-docgen-api": {
-			"version": "4.16.0",
-			"resolved": "https://registry.npmjs.org/vue-docgen-api/-/vue-docgen-api-4.16.0.tgz",
-			"integrity": "sha512-+H2mIE3SISouljiZaxlucB+nIBPc0mHQMl2pkWoPWZA+UwNKYIA7LxiLT26WZF5Aohdr+gCDAwd5NBCFxwdYgw==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/vue-docgen-api/-/vue-docgen-api-4.18.0.tgz",
+			"integrity": "sha512-y59WmG4+k26567rKKvKGT0ohhrIDlM6BJLLWVM6An44OCS+1b1vRnZvnQom2PElrhz0wNhZPbfqudlwMkyclxw==",
 			"requires": {
 				"@babel/parser": "^7.6.0",
 				"@babel/types": "^7.6.0",
@@ -19368,11 +19368,11 @@
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 		},
 		"yaml": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.8.3.tgz",
-			"integrity": "sha512-X/v7VDnK+sxbQ2Imq4Jt2PRUsRsP7UcpSl3Llg6+NRRqWLIvxkMFYtH1FmvwNGYRKKPa+EPA4qDBlI9WVG1UKw==",
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.9.2.tgz",
+			"integrity": "sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==",
 			"requires": {
-				"@babel/runtime": "^7.8.7"
+				"@babel/runtime": "^7.9.2"
 			}
 		},
 		"yargs": {

--- a/stories/cosmoz-autocomplete.stories.js
+++ b/stories/cosmoz-autocomplete.stories.js
@@ -1,21 +1,21 @@
-import { html } from "lit-html";
-import "../cosmoz-autocomplete";
+import { html } from 'lit-html';
+import '../cosmoz-autocomplete';
 
 export default {
-	title: "Autocomplete",
-	component: "cosmoz-autocomplete"
+	title: 'Autocomplete',
+	component: 'cosmoz-autocomplete'
 };
 
 export const basic = () => {
 	const words = [
-			"Red",
-			"Green",
-			"Purple",
-			"Blue",
-			"White",
-			"Brown",
-			"Aqua",
-			"Nothing"
+			'Red',
+			'Green',
+			'Purple',
+			'Blue',
+			'White',
+			'Brown',
+			'Aqua',
+			'Nothing'
 		],
 		options = Array(1e5)
 			.fill()
@@ -24,9 +24,9 @@ export const basic = () => {
 			}));
 	return html`
 		<cosmoz-autocomplete
-			.label=${"Choose color"}
+			.label=${'Choose color'}
 			.source=${options}
-			.textProperty=${"text"}
+			.textProperty=${'text'}
 		></cosmoz-autocomplete>
 	`;
 };

--- a/stories/cosmoz-autocomplete.stories.js
+++ b/stories/cosmoz-autocomplete.stories.js
@@ -1,34 +1,32 @@
-import { html } from 'lit-html';
-import '../cosmoz-autocomplete';
+import { html } from "lit-html";
+import "../cosmoz-autocomplete";
 
 export default {
-	title: 'Autocomplete',
-	component: 'cosmoz-autocomplete'
+	title: "Autocomplete",
+	component: "cosmoz-autocomplete"
 };
 
-export const singleComponent = () => {
+export const basic = () => {
 	const words = [
-			'Red',
-			'Green',
-			'Purple',
-			'Blue',
-			'White',
-			'Brown',
-			'Aqua',
-			'Nothing'
+			"Red",
+			"Green",
+			"Purple",
+			"Blue",
+			"White",
+			"Brown",
+			"Aqua",
+			"Nothing"
 		],
 		options = Array(1e5)
 			.fill()
-			.map((_, i) => {
-				return {
-					text: `${i}. ${words[Math.floor(Math.random() * words.length)]}`
-				};
-			});
+			.map((_, i) => ({
+				text: `${i}. ${words[Math.floor(Math.random() * words.length)]}`
+			}));
 	return html`
 		<cosmoz-autocomplete
-			.label=${'Choose color'}
+			.label=${"Choose color"}
 			.source=${options}
-			.textProperty=${'text'}
+			.textProperty=${"text"}
 		></cosmoz-autocomplete>
 	`;
 };


### PR DESCRIPTION
Multiple text state updates in cosmoz-autocomplete on clear are to quick for `lit-virtualizer` to handle and it does not manage to cleanup old items.
This PR fixes it.