### PR TITLE
fix: unarray value on select if limit is 1

### DIFF
--- a/lib/use-select.js
+++ b/lib/use-select.js
@@ -15,21 +15,20 @@ const useSelect = ({
 			}
 			dispatchEvent(
 				new CustomEvent('change', {
-					detail: {
-						value: unarray(value)
-					}
+					detail: { value }
 				})
 			);
 		},
 		[onChange]
 	);
 	return {
-		select: useCallback(val => {
-			onSelection([...without(val)(value), val].slice(-limit));
-		}, [
-			onSelection,
-			value
-		]),
+		select: useCallback(
+			val => {
+				const newVal = [...without(val)(value), val].slice(-limit);
+				onSelection(limit === 1 ? unarray(newVal) : newVal);
+			},
+			[onSelection, value]
+		),
 		deselect: useCallback(val => onSelection(without(val)(value)), [
 			onSelection,
 			value


### PR DESCRIPTION
If limit is 1 extract value from array to call onSelect with `value` instead of `[value]`.