### PR TITLE
feat: when items or query changes reset index to 0 instead of undefined

### DIFF
--- a/lib/use-suggestions.js
+++ b/lib/use-suggestions.js
@@ -25,17 +25,17 @@ const defaultPlacement = ['bottom-left', 'bottom-right', 'bottom', 'top-left', '
 		items,
 		onSelect
 	}) => {
-		const [index, setIndex] = useState(undefined),
+		const [index, setIndex] = useState(0),
 			{ length } = items;
 
 		useEffect(() => {
-			setIndex(undefined);
+			setIndex(0);
 		}, [items]);
 
 		useKeyboard({
-			onUp: useCallback(() => setIndex((index = -1) => index > 0 ? index - 1 : length - 1), [length]),
-			onDown: useCallback(() => setIndex((index = -1) => index < length - 1 ? index + 1 : 0), [length]),
-			onEnter: useCallback(() => index != null && onSelect?.(items[index], index), [
+			onUp: useCallback(() => setIndex((index) => index > 0 ? index - 1 : length - 1), [length]),
+			onDown: useCallback(() => setIndex((index) => index < length - 1 ? index + 1 : 0), [length]),
+			onEnter: useCallback(() => onSelect?.(items[index], index), [
 				index,
 				items,
 				onSelect

--- a/lib/use-suggestions.js
+++ b/lib/use-suggestions.js
@@ -33,8 +33,8 @@ const defaultPlacement = ['bottom-left', 'bottom-right', 'bottom', 'top-left', '
 		}, [items]);
 
 		useKeyboard({
-			onUp: useCallback(() => setIndex((index) => index > 0 ? index - 1 : length - 1), [length]),
-			onDown: useCallback(() => setIndex((index) => index < length - 1 ? index + 1 : 0), [length]),
+			onUp: useCallback(() => setIndex(index => index > 0 ? index - 1 : length - 1), [length]),
+			onDown: useCallback(() => setIndex(index => index < length - 1 ? index + 1 : 0), [length]),
 			onEnter: useCallback(() => onSelect?.(items[index], index), [
 				index,
 				items,

--- a/test/cosmoz-suggestions.test.js
+++ b/test/cosmoz-suggestions.test.js
@@ -36,7 +36,7 @@ suite('cosmoz-suggestions', () => {
 
 		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
 		assert.isTrue(onSelect.calledOnce);
-		assert.isTrue(onSelect.calledWith(items[2]));
+		assert.isTrue(onSelect.calledWith(items[3]));
 	});
 
 	test('render (textual)', async () => {

--- a/test/use-suggestions.test.js
+++ b/test/use-suggestions.test.js
@@ -21,13 +21,13 @@ suite('use-suggestions', () => {
 				<use-suggestions .items=${ [0, 1, 2] } />
 			`
 		);
-		assert.isUndefined(result.current.index);
+		assert.equal(result.current.index, 0);
 		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Down' }));
 		await nextFrame();
-		assert.equal(result.current.index, 0);
+		assert.equal(result.current.index, 1);
 	});
 
-	test('down', async () => {
+	test('down(cycle)', async () => {
 		const result = await fixture(
 			html`
 				<use-suggestions .items=${ [0, 1, 2] } />
@@ -60,7 +60,7 @@ suite('use-suggestions', () => {
 				<use-suggestions .items=${ [0, 1, 2] } />
 			`
 		);
-		assert.isUndefined(result.current.index);
+		assert.equal(result.current.index, 0);
 		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
 		await nextFrame();
 		assert.equal(result.current.index, 2);
@@ -73,7 +73,7 @@ suite('use-suggestions', () => {
 					<use-suggestions .items=${ items } />
 				`
 			);
-		assert.isUndefined(result.current.index);
+		assert.equal(result.current.index, 0);
 		result.current.highlight(1);
 		await nextFrame();
 		assert.equal(result.current.index, 1);
@@ -100,7 +100,8 @@ suite('use-suggestions', () => {
 			`
 		);
 		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
-		assert.isFalse(onSelect.calledOnce);
+		assert.isTrue(onSelect.calledOnce);
+		assert.isTrue(onSelect.calledWith(0));
 	});
 
 	test('enter', async () => {


### PR DESCRIPTION
In cosmoz-autocomplete we currently reset the selection `index` to undefined whenever `items` changes.
It makes more sense to reset the selection to '0' instead to allow the user to quickly highlight the first item (because query helps to remove unwanted items) and press `Enter` to select.