### PR TITLE
fix: add text and value events

### DIFF
--- a/lib/use-autocomplete.js
+++ b/lib/use-autocomplete.js
@@ -4,18 +4,24 @@ import {
 import {
 	without, search, strProp
 } from './utils';
+import { useHost } from '@neovici/cosmoz-utils/lib/hooks/use-host';
 import { useBackspace } from './use-backspace';
-
-const EMPTY = [],
+const
+	EMPTY = [],
+	notify = (host, name, detail) => host.dispatchEvent(new CustomEvent(name, { detail })),
+	useNotify = (host, fn, name) => useCallback(val => {
+		fn?.(val);
+		notify(host, name, val);
+	}, [fn, host]),
 	useAutocomplete = ({
 		value,
-		onChange,
+		text,
+		onChange: _onChange,
+		onText: _onText,
 		limit,
 		source,
 		onFocus,
-		text,
 		textProperty,
-		onText,
 		external,
 		disabled
 	}) => {
@@ -23,7 +29,10 @@ const EMPTY = [],
 			textual = useMemo(() => strProp(textProperty), [textProperty]),
 			values = useMemo(() => without(value)(source), [source, value]),
 			[focused, setFocused] = useState(false),
-			query = useMemo(() => text?.trim().toLowerCase(), [text]);
+			query = useMemo(() => text?.trim().toLowerCase(), [text]),
+			host = useHost(),
+			onText = useNotify(host, _onText, 'text'),
+			onChange = useNotify(host, _onChange, 'value');
 
 		useBackspace({
 			focused,
@@ -42,11 +51,10 @@ const EMPTY = [],
 				}
 				return query && !external ? search(values, query, textual) : values;
 			}, [focused, values, query, textual, external, disabled]),
-
 			onText: useCallback(
 				e => {
 					const newText = e.target.value;
-					newText !== text && onText?.(newText);
+					newText !== text && onText(newText);
 				},
 				[onText, text]
 			),
@@ -57,13 +65,13 @@ const EMPTY = [],
 			}, [setFocused, onFocus]),
 			onSelect: useCallback(
 				newVal => {
-					onText?.('');
-					onChange?.([...without(newVal)(value), newVal].slice(-limit));
+					onText('');
+					onChange([...without(newVal)(value), newVal].slice(-limit));
 				},
 				[onText, onChange, value, limit]
 			),
 			onDeselect: useCallback(val => {
-				onChange?.(without(val)(value));
+				onChange(without(val)(value));
 			}, [
 				onChange,
 				value


### PR DESCRIPTION
Add events for `text` and `value` state changes.
Useful when we need to use that instead of onText, onChange props.