### PR TITLE
fix: use input as anchor for suggestions

### DIFF
--- a/lib/autocomplete.js
+++ b/lib/autocomplete.js
@@ -1,12 +1,10 @@
-import {
-	html, nothing
-} from 'lit-html';
+import { html, nothing } from 'lit-html'; // eslint-disable-line object-curly-newline
 import { live } from 'lit-html/directives/live';
-
-import { array } from './utils';
-import { useAutocomplete } from './use-autocomplete';
+import { useCallback } from 'haunted';
 import { portal } from '@neovici/cosmoz-utils/lib/directives/portal';
 import { useHost } from '@neovici/cosmoz-utils/lib/hooks/use-host';
+import { array } from './utils';
+import { useAutocomplete } from './use-autocomplete';
 
 import '@polymer/paper-input/paper-input';
 import '../cosmoz-suggestions';
@@ -105,7 +103,8 @@ const chip = (text, onClear, disabled) => html`
 		const host = useHost(),
 			$chips = chips(value, textual, onDeselect, disabled),
 			isOne = limit === 1 || limit === '1',
-			isSingle = isOne && array(value)?.[0] != null;
+			isSingle = isOne && array(value)?.[0] != null,
+			anchor = useCallback(() => host.shadowRoot.querySelector('#input'), [host, value]);
 		return html`
 			<style>${ style }</style>
 
@@ -137,7 +136,7 @@ const chip = (text, onClear, disabled) => html`
 					.items=${ items }
 					.onSelect=${ onSelect }
 					.textual=${ textual }
-					.anchor=${ host }
+					.anchor=${ anchor }
 					.confinement=${ confinement }
 					.placement=${ placement }
 				/>`) || nothing }

--- a/lib/use-suggestions.js
+++ b/lib/use-suggestions.js
@@ -60,9 +60,10 @@ const defaultPlacement = ['bottom-left', 'bottom-right', 'bottom', 'top-left', '
 	},
 
 	usePosition = ({
-		anchor, host, confinement, placement
+		anchor: anchorage, host, confinement, placement
 	}) => {
 		useEffect(() => {
+			const anchor = typeof anchorage === 'function' ? anchorage() : anchorage;
 			if (anchor == null) {
 				return;
 			}
@@ -87,7 +88,7 @@ const defaultPlacement = ['bottom-left', 'bottom-right', 'bottom', 'top-left', '
 				window.removeEventListener('resize', onReposition, true);
 				cancelAnimationFrame(rid);
 			};
-		}, [confinement, placement]);
+		}, [anchorage, confinement, placement]);
 	},
 
 	useSuggestions = host => {


### PR DESCRIPTION
Instead of using the full `cosmoz-autocomplete` element as anchor for
suggestions use the input element instead. This fixes misc issues in frontend
and allows to use suggestions for other inputs too.