### PR TITLE
refactor: add only one listener on attach for use-keyboard

### DIFF
--- a/lib/use-keyboard.js
+++ b/lib/use-keyboard.js
@@ -1,8 +1,9 @@
 import { useEffect } from 'haunted';
+import { useMeta } from '@neovici/cosmoz-utils/lib/hooks/use-meta';
 
-export const useKeyboard = ({
-	onUp, onDown, onEnter
-}) => {
+export const useKeyboard = handlers => {
+	const listeners = useMeta(handlers);
+
 	useEffect(() => {
 		const handler = e => {
 			if (e.ctrlKey && e.altKey || e.defaultPrevented) {
@@ -12,16 +13,16 @@ export const useKeyboard = ({
 			case 'Up':
 			case 'ArrowUp':
 				e.preventDefault();
-				onUp();
+				listeners.onUp();
 				break;
 			case 'Down':
 			case 'ArrowDown':
 				e.preventDefault();
-				onDown();
+				listeners.onDown();
 				break;
 			case 'Enter':
 				e.preventDefault();
-				onEnter();
+				listeners.onEnter();
 				break;
 			default:
 				break;
@@ -30,5 +31,5 @@ export const useKeyboard = ({
 
 		document.addEventListener('keydown', handler, true);
 		return () => document.removeEventListener('keydown', handler, true);
-	}, [onUp, onDown, onEnter]);
+	}, [listeners]);
 };

--- a/lib/use-suggestions.js
+++ b/lib/use-suggestions.js
@@ -1,10 +1,11 @@
 import {
-	useCallback, useEffect, useMemo, useState
+	useCallback, useEffect, useState
 } from 'haunted';
 import getPosition from 'position.js';
 import { useKeyboard } from './use-keyboard';
 import { onScrolled } from './on-scrolled';
 import defaultItemRenderer from './item-renderer';
+import { useMeta } from '@neovici/cosmoz-utils/lib/hooks/use-meta';
 
 const defaultPlacement = ['bottom-left', 'bottom-right', 'bottom', 'top-left', 'top-right', 'top'],
 	position = (host, anchor, placement = defaultPlacement, confinement) => {
@@ -53,9 +54,7 @@ const defaultPlacement = ['bottom-left', 'bottom-right', 'bottom', 'top-left', '
 		itemRenderer = defaultItemRenderer,
 		...meta
 	}) => {
-		const ref = useMemo(() => ({}), []),
-			info = useMemo(() => Object.assign(ref, meta), [ref, ...Object.values(meta)]);
-
+		const info = useMeta(meta);
 		return useCallback((item, i) => itemRenderer(item, i, info), [info, itemRenderer]);
 	},
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1704,9 +1704,9 @@
 			"dev": true
 		},
 		"@neovici/cosmoz-input": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-input/-/cosmoz-input-1.0.4.tgz",
-			"integrity": "sha512-3b6CxC8du+/VfWxCuWOVm2zAWcqtiVovzcNsApaeaB5ryHGAl2IYRqkqG7fUxlu3aP6slI+4CuUKakFsVEFxiQ==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-input/-/cosmoz-input-1.0.8.tgz",
+			"integrity": "sha512-tsSNBym1dC8XVD/I3AuCn+fOvYPp6FMVjoZi/vxwx/YdlMybuhxM/LoqFsNJp+VvcJNq9Xzkb/wi97GAwHOjtg==",
 			"requires": {
 				"@neovici/cosmoz-utils": "^3.15.0",
 				"haunted": "^4.7.0",
@@ -1714,9 +1714,9 @@
 			}
 		},
 		"@neovici/cosmoz-utils": {
-			"version": "3.15.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-utils/-/cosmoz-utils-3.15.0.tgz",
-			"integrity": "sha512-BqHnar9CcLqJ8zl2pf1WrXK8gGswyHrxshBergoVvbXDb5vqW4m7xQBi5PeAIWPtCMp1lRNAVFJ38G903E2COw==",
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-utils/-/cosmoz-utils-3.16.0.tgz",
+			"integrity": "sha512-zNM0RgyN2m60FHI9Molx5f8lWow/iqlsPJDBm7A5XYPUYcbngnJUZ/ErzY8rGIxvjOfyrT1k/YAsHyPn8Dt48Q==",
 			"requires": {
 				"haunted": "^4.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
 		}
 	},
 	"dependencies": {
-		"@neovici/cosmoz-input": "^1.0.4",
-		"@neovici/cosmoz-utils": "^3.15.0",
+		"@neovici/cosmoz-input": "^1.0.8",
+		"@neovici/cosmoz-utils": "^3.16.0",
 		"haunted": "^4.7.0",
 		"lit-html": "^1.2.1",
 		"lit-virtualizer": "^0.4.2",


### PR DESCRIPTION
Reduce the amount of added and removed event listeners by only
adding one when attached and removing it on detach