### PR TITLE
feat(autocomplete): support function and/or Promise source

### DIFF
--- a/lib/autocomplete.js
+++ b/lib/autocomplete.js
@@ -1,5 +1,6 @@
 import { html, nothing } from 'lit-html'; // eslint-disable-line object-curly-newline
 import { live } from 'lit-html/directives/live';
+import { until } from 'lit-html/directives/until';
 import { useCallback } from 'haunted';
 import { portal } from '@neovici/cosmoz-utils/lib/directives/portal';
 import { useHost } from '@neovici/cosmoz-utils/lib/hooks/use-host';
@@ -8,7 +9,9 @@ import { array } from './utils';
 import { useAutocomplete } from './use-autocomplete';
 import '../cosmoz-suggestions';
 
-const chip = (text, onClear, disabled) => html`
+const
+	blank = () => nothing,
+	renderChip = (text, onClear, disabled) => html`
 		<div class="chip" part="chip" title=${ text }>
 			<span class="chip-text" part="chip-text">${ text }</span>
 			${ !disabled && html`
@@ -19,8 +22,8 @@ const chip = (text, onClear, disabled) => html`
 			</span>` || nothing }
 		</div>
 	`,
-	chips = (value, textual, onDeselect, disabled) => array(value).map(value =>
-		chip(textual(value), () => onDeselect(value), disabled)
+	renderChips = (value, textual, onDeselect, disabled) => array(value).map(value =>
+		renderChip(textual(value), () => onDeselect(value), disabled)
 	),
 	style = `
 		:host {
@@ -77,40 +80,76 @@ const chip = (text, onClear, disabled) => html`
 		slot {
 			display: contents !important;
 		}
+
+		@keyframes rotating {
+			100% {
+				transform: rotate(360deg);
+			}
+		}
+		.spinner {
+			border-radius: 50%;
+			width: 22px;
+			height: 22px;
+			border: 2px solid rgba(0, 0, 0, 0.1);
+			border-top: 2px solid #5f5a92;
+			animation: rotating 1.2s infinite cubic-bezier(0.785, 0.135, 0.15, 0.86);
+			box-sizing: border-box;
+			margin-top: -3px;
+		}
 	`,
+
 	inputParts = ['input', 'label', 'line', 'error'].map(part => `${ part }: input-${ part }`).join(),
-	autocomplete = ({
-		invalid,
-		errorMessage,
-		label,
-		placeholder,
-		disabled,
-		noLabelFloat,
-		alwaysFloatLabel,
-		textual,
-		text,
-		query,
-		onText,
-		onFocus,
-		onSelect,
-		onDeselect,
-		value,
-		items,
-		limit,
-		confinement,
-		placement,
-		defaultIndex
-	}) => {
-		const host = useHost(),
-			$chips = chips(value, textual, onDeselect, disabled),
+	renderSuggestions = ({
+		query, items, onSelect, textual, anchor, confinement, placement, defaultIndex
+	}) => portal(html`
+		<cosmoz-suggestions
+			.query=${ query }
+			.items=${ items }
+			.onSelect=${ onSelect }
+			.textual=${ textual }
+			.anchor=${ anchor }
+			.confinement=${ confinement }
+			.placement=${ placement }
+			.defaultIndex=${ isNaN(defaultIndex) ? undefined : Number(defaultIndex) }
+		></cosmoz-suggestions>`),
+
+	autocomplete = props => {
+		const
+			{
+				invalid,
+				errorMessage,
+				label,
+				placeholder,
+				disabled,
+				noLabelFloat,
+				alwaysFloatLabel,
+				textual,
+				text,
+				onText,
+				onFocus,
+				onDeselect,
+				value,
+				limit,
+				items$,
+				values$
+			} = props,
+			host = useHost(),
+
+			chips = renderChips(value, textual, onDeselect, disabled),
 			isOne = limit == 1, //eslint-disable-line eqeqeq
 			isSingle = isOne && array(value)?.[0] != null,
-			anchor = useCallback(() => host.shadowRoot.querySelector('#input'), [host, value]);
+			anchor = useCallback(() => host.shadowRoot.querySelector('#input'), [host, value]),
+
+			suggestions = until(items$.then(items => !isSingle && items.length && renderSuggestions({
+				...props,
+				anchor,
+				items
+			}) || nothing));
 
 		return html`
 			<style>${ style }</style>
 
-			${ !isOne && html`<div class="chips">${ $chips }</div>` || '' }
+			${ !isOne && html`<div class="chips">${ chips }</div>` || '' }
 
 			<cosmoz-input
 				id="input" part="input"
@@ -120,8 +159,8 @@ const chip = (text, onClear, disabled) => html`
 				?always-float-label=${ isSingle || alwaysFloatLabel }
 				?readonly=${ isSingle }
 				?disabled=${ disabled }
-				?invalid=${ invalid }
-				.errorMessage=${ errorMessage }
+				?invalid=${ until(values$.then(() => invalid, () => true), invalid) }
+				.errorMessage=${ until(values$.then(() => errorMessage, e => e.message), errorMessage) }
 				.value=${ live(text) }
 				@value-changed=${ onText }
 				@focused-changed=${ onFocus }
@@ -130,21 +169,10 @@ const chip = (text, onClear, disabled) => html`
 			>
 				<slot name="prefix" slot="prefix"></slot>
 				<slot name="suffix" slot="suffix"></slot>
-				${ isOne && html`<div class="chips" slot="prefix">${ $chips }</div>` || '' }
+				${ isOne && html`<div class="chips" slot="prefix">${ chips }</div>` || '' }
+				${ until(values$.then(blank, blank), html`<div slot="suffix" class="spinner"></div>`) }
 			</cosmoz-input>
-
-			${ !isSingle && items.length && portal(html`
-				<cosmoz-suggestions
-					.query=${ query }
-					.items=${ items }
-					.onSelect=${ onSelect }
-					.textual=${ textual }
-					.anchor=${ anchor }
-					.confinement=${ confinement }
-					.placement=${ placement }
-					.defaultIndex=${ isNaN(defaultIndex) ? undefined : Number(defaultIndex) }
-				/>`) || nothing }
-		`;
+			${ suggestions }`;
 	},
 	Autocomplete = props => autocomplete({
 		...props,

--- a/lib/use-autocomplete.js
+++ b/lib/use-autocomplete.js
@@ -8,6 +8,7 @@ import { useHost } from '@neovici/cosmoz-utils/lib/hooks/use-host';
 import { useKeys } from './use-keys';
 const
 	EMPTY = [],
+	EMPTY$ = Promise.resolve(EMPTY),
 	notify = (host, name, detail) => host.dispatchEvent(new CustomEvent(name, { detail })),
 	useNotify = (host, fn, name) => useCallback(val => {
 		fn?.(val);
@@ -28,14 +29,21 @@ const
 	}) => {
 		const
 			textual = useMemo(() => strProp(textProperty), [textProperty]),
-			values = useMemo(() => without(value)(source), [source, value]),
 			[focused, setFocused] = useState(false),
 			active = focused && !disabled,
 			empty = !text,
 			query = useMemo(() => text?.trim().toLowerCase(), [text]),
 			host = useHost(),
 			onText = useNotify(host, _onText, 'text'),
-			onChange = useNotify(host, _onChange, 'value');
+			onChange = useNotify(host, _onChange, 'value'),
+			source$ = useMemo(() => Promise.resolve(typeof source === 'function'
+				? source({
+					query,
+					active
+				})
+				: source
+			), [source, active, query]),
+			values$ = useMemo(() => source$.then(without(value)), [source$, value]);
 
 		useKeys({
 			active,
@@ -51,12 +59,15 @@ const
 			query,
 			textual,
 			focused,
-			items: useMemo(() => {
+			values$,
+			items$: useMemo(() => {
 				if (!active || hideEmpty && empty) {
-					return EMPTY;
+					return EMPTY$;
 				}
-				return query && !external ? search(values, query, textual) : values;
-			}, [active, values, query, textual, external, hideEmpty, empty]),
+				return query && !external
+					? values$.then(values => search(values, query, textual))
+					: values$;
+			}, [values$, active, query, textual, external, hideEmpty, empty]),
 			onText: useCallback(
 				e => {
 					const newText = e.target.value;

--- a/test/use-autocomplete.test.js
+++ b/test/use-autocomplete.test.js
@@ -22,7 +22,7 @@ suite('use-autocomplete', () => {
 			`);
 		assert.equal(result.current.query, 'it');
 		assert.isFalse(result.current.focused);
-		assert.lengthOf(result.current.items, 0);
+		assert.lengthOf(await result.current.items$, 0);
 	});
 
 	test('focus', async () => {
@@ -32,10 +32,11 @@ suite('use-autocomplete', () => {
 				<use-autocomplete .source=${ source } .value=${ source[0] } .text=${ 'It' } .textProperty=${ 'text' }
 					.onFocus=${ onFocus } />
 			`);
-		assert.lengthOf(result.current.items, 0);
+
+		assert.lengthOf(await result.current.items$, 0);
 		result.current.onFocus({ target: { focused: true }});
 		await nextFrame();
-		assert.lengthOf(result.current.items, 1);
+		assert.lengthOf(await result.current.items$, 1);
 		assert.isTrue(onFocus.calledOnce);
 		assert.isTrue(onFocus.calledWith(true));
 	});
@@ -94,6 +95,6 @@ suite('use-autocomplete', () => {
 		assert.equal(result.current.query, 'la');
 		result.current.onFocus({ target: { focused: true }});
 		await nextFrame();
-		assert.lengthOf(result.current.items, 2);
+		assert.lengthOf(await result.current.items$, 2);
 	});
 });


### PR DESCRIPTION
`source` can now be promise or a function that returns promise that
is called with `active` (`!disabled` and `focused` ) and `query` (trimmed text).
If `source` is a Promise than a spinner is shown when pending and any errors
are caught and passed to `cosmoz-input` to be displayed (invalid, error-message).

Fixes #96

Example usage: 

```
<cosmoz-autocomplete 
      text-property="label" 
      external
      .source=${ debounce(({query})=> fetch(`api/items?query=${query}`).then((r)=>r.json())) }
><cosmoz-autocomplete>
```