### PR TITLE
fix(autocomplete): remove one chip max-width

### DIFF
--- a/lib/autocomplete.css.js
+++ b/lib/autocomplete.css.js
@@ -54,6 +54,7 @@ export default css`
 		margin: 0;
 		z-index: 2;
 		pointer-events: auto;
+		max-width: initial;
 	}
 	.chip-text {
 		color: var(--cosmoz-autocomplete-chip-color, #424242);


### PR DESCRIPTION
Removes the max width when displaying one chip in multi mode.
