### PR TITLE
fix: chips no longer hovering other omnitable fields

### DIFF
--- a/src/autocomplete/chip.css.ts
+++ b/src/autocomplete/chip.css.ts
@@ -10,7 +10,7 @@ export default css`
 		align-items: center;
 		flex: 0.0001 1 fit-content;
 		max-width: 18ch;
-		min-width: 40px;
+		min-width: 12px;
 		padding: 0 4px 0 8px;
 		gap: 4px;
 	}
@@ -22,7 +22,7 @@ export default css`
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		flex: auto;
-		min-width: 16px;
+		min-width: 4px;
 	}
 	.clear {
 		background-color: var(--cosmoz-autocomplete-chip-clear-bg-color, #81899b);


### PR DESCRIPTION
Bug [AB#10800](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/10800) - chips' minimum dimension caused overlap with other omnitable headers. This PR should fix it reducing their minimum size.

![image](https://github.com/Neovici/cosmoz-autocomplete/assets/122988480/8d1b86d7-8362-4a64-9846-98a921850b8a)
