### PR TITLE
AB#11535 useImperativeApi focus function

### DIFF
--- a/src/autocomplete/autocomplete.ts
+++ b/src/autocomplete/autocomplete.ts
@@ -4,6 +4,7 @@ import { until } from 'lit-html/directives/until.js';
 import { when } from 'lit-html/directives/when.js';
 import { useCallback } from 'haunted';
 import { useHost } from '@neovici/cosmoz-utils/hooks/use-host';
+import { useImperativeApi } from '@neovici/cosmoz-utils/hooks/use-imperative-api';
 import '@neovici/cosmoz-input';
 import { useAutocomplete, Props as Base, RProps } from './use-autocomplete';
 import { listbox } from '../listbox';
@@ -75,6 +76,16 @@ const autocomplete = <I>(props: AProps<I>) => {
 					)
 				)
 			);
+
+		useImperativeApi(
+			{
+				focus: () =>
+					(
+						host.shadowRoot?.querySelector('#input') as HTMLInputElement
+					)?.focus(),
+			},
+			[]
+		);
 
 		return html` <style>
 				${style}

--- a/src/autocomplete/index.ts
+++ b/src/autocomplete/index.ts
@@ -35,5 +35,12 @@ customElements.define(
 );
 customElements.define(
 	'cosmoz-autocomplete',
-	component<Props<unknown>>(Standalone, { observedAttributes })
+	component<Props<unknown>>(Standalone, {
+		observedAttributes,
+		baseElement: class extends HTMLElement {
+			focus() {
+				(this.shadowRoot?.querySelector('#input') as HTMLInputElement).focus();
+			}
+		},
+	})
 );

--- a/src/autocomplete/index.ts
+++ b/src/autocomplete/index.ts
@@ -35,12 +35,5 @@ customElements.define(
 );
 customElements.define(
 	'cosmoz-autocomplete',
-	component<Props<unknown>>(Standalone, {
-		observedAttributes,
-		baseElement: class extends HTMLElement {
-			focus() {
-				(this.shadowRoot?.querySelector('#input') as HTMLInputElement).focus();
-			}
-		},
-	})
+	component<Props<unknown>>(Standalone, { observedAttributes })
 );


### PR DESCRIPTION
[AB#11535](https://dev.azure.com/neovici/Cosmoz3/_workitems/edit/11535/)

Uses `useImperativeApi` to expose focus function to the outer world to be able to focus on the auto-complete input.