### PR TITLE
chore(cosmoz-input): dependencies update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@lit-labs/virtualizer": "^2.0.0",
 				"@neovici/cosmoz-dropdown": "^3.4.0",
-				"@neovici/cosmoz-input": "^3.11.0",
+				"@neovici/cosmoz-input": "^3.18.0",
 				"@neovici/cosmoz-utils": "^5.0.0",
 				"haunted": "^5.0.0",
 				"lit-html": "^2.0.0 || ^3.0.0"
@@ -3127,9 +3127,9 @@
 			}
 		},
 		"node_modules/@neovici/cosmoz-input": {
-			"version": "3.15.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-input/-/cosmoz-input-3.15.0.tgz",
-			"integrity": "sha512-hV21XG1X1uyKCBpGa3Kun/odWSHqxgqfHfxdQ4XtqYqcMoy5Mc+UQX22igfJCddNozJUvumn2ajE/u9RaeC83A==",
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-input/-/cosmoz-input-3.18.0.tgz",
+			"integrity": "sha512-Onjoidylp+DbgNByfxQOWtTlGjpFezkapc6vtO5IKZS53yZtX3m4XaCm9gXxZvEKPF12gXBD9rqJxNdD6651Qg==",
 			"dependencies": {
 				"@neovici/cosmoz-utils": "^5.1.0",
 				"haunted": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 	"dependencies": {
 		"@lit-labs/virtualizer": "^2.0.0",
 		"@neovici/cosmoz-dropdown": "^3.4.0",
-		"@neovici/cosmoz-input": "^3.11.0",
+		"@neovici/cosmoz-input": "^3.18.0",
 		"@neovici/cosmoz-utils": "^5.0.0",
 		"haunted": "^5.0.0",
 		"lit-html": "^2.0.0 || ^3.0.0"


### PR DESCRIPTION
Dependencies update after the latest release in [`cosmoz-input`](https://github.com/Neovici/cosmoz-input/pull/71)