### PR TITLE
Fix(dependencies/chip): latest input dependencies and new styling for the chip tested

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@lit-labs/virtualizer": "^2.0.0",
 				"@neovici/cosmoz-dropdown": "^4.0.0",
-				"@neovici/cosmoz-input": "^4.0.0",
+				"@neovici/cosmoz-input": "^4.1.1",
 				"@neovici/cosmoz-utils": "^6.0.0",
 				"@pionjs/pion": "^2.0.0",
 				"lit-html": "^2.0.0 || ^3.0.0"
@@ -3345,9 +3345,9 @@
 			}
 		},
 		"node_modules/@neovici/cosmoz-input": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-input/-/cosmoz-input-4.0.0.tgz",
-			"integrity": "sha512-c0ZkxOAOm3wPT9LEUAitNc7+a/meW3yhxGZrqDaLmodqcw7lIXRNZpiMN4E+ekdxHuq3RViM1TrWTUwqhiCxyA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-input/-/cosmoz-input-4.1.1.tgz",
+			"integrity": "sha512-F9IsfPX3rp1kNpLACF/VCStJ8cc4R8Y4rtEU5UjVHVb0of4r6skMe09PsxfSBsDjkPql9d09xUM3LP+givbT7A==",
 			"dependencies": {
 				"@neovici/cosmoz-utils": "^6.0.0",
 				"@pionjs/pion": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 	"dependencies": {
 		"@lit-labs/virtualizer": "^2.0.0",
 		"@neovici/cosmoz-dropdown": "^4.0.0",
-		"@neovici/cosmoz-input": "^4.0.0",
+		"@neovici/cosmoz-input": "^4.1.1",
 		"@neovici/cosmoz-utils": "^6.0.0",
 		"@pionjs/pion": "^2.0.0",
 		"lit-html": "^2.0.0 || ^3.0.0"

--- a/src/autocomplete/autocomplete.ts
+++ b/src/autocomplete/autocomplete.ts
@@ -31,7 +31,7 @@ type AProps<I> = Omit<Props<I>, keyof RProps<I>> &
 
 const blank = () => nothing;
 
-const inputParts = ['input', 'control', 'label', 'line', 'error']
+const inputParts = ['input', 'control', 'label', 'line', 'error', 'chip', 'chip-text', 'chip-clear']
 	.map((part) => `${part}: input-${part}`)
 	.join();
 

--- a/stories/cosmoz-autocomplete.stories.js
+++ b/stories/cosmoz-autocomplete.stories.js
@@ -82,9 +82,41 @@ const css = html`
 			.textProperty=${'text'}
 			.value=${colors[0]}
 		></cosmoz-autocomplete>
-	`;
+	`,
+	contourStyling = () => html` <style>
+			cosmoz-autocomplete {
+				--cosmoz-input-border-radius: 4px;
+				--cosmoz-input-padding: 8px 0;
+				--cosmoz-input-label-width: auto;
+				--cosmoz-input-no-placeholder-label-bg: white;
+				--cosmoz-input-label-padding: 0;
+				--cosmoz-input-line-display: none;
+				--cosmoz-input-contour-size: 1px;
+				--cosmoz-input-background: white;
+				--cosmoz-autocomplete-chip-border-radius: 4px;
+			}
+			cosmoz-autocomplete::part(input-control) {
+				margin: 0 8px;
+			}
+		</style>
+		<cosmoz-autocomplete
+			.placeholder=${'Choose color'}
+			.source=${colors}
+			.limit=${1}
+			.textProperty=${'text'}
+			.value=${colors[0]}
+			contour
+		></cosmoz-autocomplete>`;
 
-export { basic, single, hideEmpty, defaultIndex, disabled, placeholder };
+export {
+	basic,
+	single,
+	hideEmpty,
+	defaultIndex,
+	disabled,
+	placeholder,
+	contourStyling,
+};
 
 export const overflown = () => html` ${css}
 	<cosmoz-autocomplete

--- a/stories/cosmoz-autocomplete.stories.js
+++ b/stories/cosmoz-autocomplete.stories.js
@@ -98,11 +98,14 @@ const css = html`
 			cosmoz-autocomplete::part(input-control) {
 				margin: 0 8px;
 			}
+			cosmoz-autocomplete::part(chip-clear) {
+				margin-left: 4px;
+			}
 		</style>
 		<cosmoz-autocomplete
-			.placeholder=${'Choose color'}
+			.label=${'Choose color'}
 			.source=${colors}
-			.limit=${1}
+			.limit=${5}
 			.textProperty=${'text'}
 			.value=${colors[0]}
 			contour


### PR DESCRIPTION
About feature [AB#11519](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/11519) - part of the inputs restyling. Dependencies update and testing of a more squared chip for the new input design.
![image](https://github.com/Neovici/cosmoz-autocomplete/assets/122988480/b2c30972-d0a5-4905-8ff1-d950ac1a5e27)
