### PR TITLE
fix(dependencies): newest cosmoz input needed in this repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@lit-labs/virtualizer": "^2.0.0",
 				"@neovici/cosmoz-dropdown": "^4.4.0",
-				"@neovici/cosmoz-input": "^4.3.3",
+				"@neovici/cosmoz-input": "^5.0.0",
 				"@neovici/cosmoz-utils": "^6.0.0",
 				"@pionjs/pion": "^2.0.0",
 				"lit-html": "^2.0.0 || ^3.0.0"
@@ -4136,9 +4136,9 @@
 			}
 		},
 		"node_modules/@neovici/cosmoz-input": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-input/-/cosmoz-input-4.3.3.tgz",
-			"integrity": "sha512-UZZxQ7QMV19nYUM5YuwSanD3GdCF1YrKCCzsoJFmCTrBRrdkRV/alrb1n65jmiVfOuPIEpEESiAJYJEKiQPPgg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-input/-/cosmoz-input-5.0.0.tgz",
+			"integrity": "sha512-/VgXn27TJ/dPJd3aUoyoso6NIMr4Q6duWR4chxPTc5m70g9fHLB1fTO7/Ph9rUYejYRNUZZ4ie+pNfTl0Cbneg==",
 			"dependencies": {
 				"@neovici/cosmoz-utils": "^6.0.0",
 				"@pionjs/pion": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 	"dependencies": {
 		"@lit-labs/virtualizer": "^2.0.0",
 		"@neovici/cosmoz-dropdown": "^4.4.0",
-		"@neovici/cosmoz-input": "^4.3.3",
+		"@neovici/cosmoz-input": "^5.0.0",
 		"@neovici/cosmoz-utils": "^6.0.0",
 		"@pionjs/pion": "^2.0.0",
 		"lit-html": "^2.0.0 || ^3.0.0"


### PR DESCRIPTION
About Feature [AB#11519](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/11519) - latest `cosmoz-input` release (v5.0.0) needs to be installed in all the components using it.