### PR TITLE
Fix the listbox `min-height` issue and remove the popover padding

### DIFF
--- a/src/listbox/index.ts
+++ b/src/listbox/index.ts
@@ -12,7 +12,6 @@ import { component, html, useEffect, useMemo, useRef } from '@pionjs/pion';
 import { ref } from 'lit-html/directives/ref.js';
 import style, { styles } from './style.css';
 import { Props, properties, useListbox } from './use-listbox';
-import { styleMap } from 'lit-html/directives/style-map.js';
 
 const Listbox = <I>(props: Props<I>) => {
 	const listRef = useRef<Element | undefined>(undefined);
@@ -40,7 +39,7 @@ const Listbox = <I>(props: Props<I>) => {
 	return html`<div
 		class="items"
 		${ref((el) => (listRef.current = el))}
-		style="${styleMap({ minHeight: height + 'px' })}"
+		style="min-height: ${height}px"
 	>
 		<div virtualizer-sizer></div>
 		${virtualize({

--- a/src/listbox/index.ts
+++ b/src/listbox/index.ts
@@ -12,6 +12,7 @@ import { component, html, useEffect, useMemo, useRef } from '@pionjs/pion';
 import { ref } from 'lit-html/directives/ref.js';
 import style, { styles } from './style.css';
 import { Props, properties, useListbox } from './use-listbox';
+import { styleMap } from 'lit-html/directives/style-map.js';
 
 const Listbox = <I>(props: Props<I>) => {
 	const listRef = useRef<Element | undefined>(undefined);
@@ -36,7 +37,11 @@ const Listbox = <I>(props: Props<I>) => {
 		[itemHeight],
 	);
 
-	return html`<div class="items" ${ref((el) => (listRef.current = el))}>
+	return html`<div
+		class="items"
+		${ref((el) => (listRef.current = el))}
+		style="${styleMap({ minHeight: height + 'px' })}"
+	>
 		<div virtualizer-sizer></div>
 		${virtualize({
 			items,

--- a/src/listbox/style.css.ts
+++ b/src/listbox/style.css.ts
@@ -24,6 +24,9 @@ const style = css`
 		margin: 0;
 		border: 0;
 	}
+	:host([popover]) {
+		padding: 0;
+	}
 	.items {
 		position: relative;
 		overflow-y: auto;

--- a/stories/cosmoz-autocomplete.stories.js
+++ b/stories/cosmoz-autocomplete.stories.js
@@ -3,7 +3,7 @@ import { html } from 'lit-html';
 import { styleMap } from 'lit-html/directives/style-map.js';
 import { classMap } from 'lit-html/directives/class-map.js';
 import '../src/autocomplete';
-import { colors, aFewColors } from './data';
+import { colors } from './data';
 
 const CSS = html`
 	<style>
@@ -178,38 +178,6 @@ export const Basic = {
 		docs: {
 			description: {
 				story: 'The basic version',
-			},
-		},
-	},
-};
-
-export const BasicWithAFewColors = {
-	args: {
-		label: 'Choose colors',
-		source: aFewColors,
-		textProperty: 'text',
-		value: [aFewColors[0], aFewColors[1]],
-	},
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'The basic version with a few items in the source, good for testing the smaller than 150px min height edge case',
-			},
-		},
-	},
-};
-
-export const EmptySource = {
-	args: {
-		label: 'Choose colors',
-		source: [],
-		textProperty: 'text',
-	},
-	parameters: {
-		docs: {
-			description: {
-				story: 'The empty source version',
 			},
 		},
 	},

--- a/stories/cosmoz-autocomplete.stories.js
+++ b/stories/cosmoz-autocomplete.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { html } from 'lit-html';
 import { styleMap } from 'lit-html/directives/style-map.js';
 import { classMap } from 'lit-html/directives/class-map.js';
@@ -194,6 +195,21 @@ export const BasicWithAFewColors = {
 			description: {
 				story:
 					'The basic version with a few items in the source, good for testing the smaller than 150px min height edge case',
+			},
+		},
+	},
+};
+
+export const EmptySource = {
+	args: {
+		label: 'Choose colors',
+		source: [],
+		textProperty: 'text',
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'The empty source version',
 			},
 		},
 	},

--- a/stories/cosmoz-autocomplete.stories.js
+++ b/stories/cosmoz-autocomplete.stories.js
@@ -2,7 +2,7 @@ import { html } from 'lit-html';
 import { styleMap } from 'lit-html/directives/style-map.js';
 import { classMap } from 'lit-html/directives/class-map.js';
 import '../src/autocomplete';
-import { colors } from './data';
+import { colors, aFewColors } from './data';
 
 const CSS = html`
 	<style>
@@ -177,6 +177,23 @@ export const Basic = {
 		docs: {
 			description: {
 				story: 'The basic version',
+			},
+		},
+	},
+};
+
+export const BasicWithAFewColors = {
+	args: {
+		label: 'Choose colors',
+		source: aFewColors,
+		textProperty: 'text',
+		value: [aFewColors[0], aFewColors[1]],
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'The basic version with a few items in the source, good for testing the smaller than 150px min height edge case',
 			},
 		},
 	},

--- a/stories/data.js
+++ b/stories/data.js
@@ -9,6 +9,4 @@ const colors = [
 	'Nothing',
 ].map((text) => ({ text }));
 
-const aFewColors = ['Red', 'Blue'];
-
-export { colors, aFewColors };
+export { colors };

--- a/stories/data.js
+++ b/stories/data.js
@@ -9,4 +9,6 @@ const colors = [
 	'Nothing',
 ].map((text) => ({ text }));
 
-export { colors };
+const aFewColors = ['Red', 'Blue'];
+
+export { colors, aFewColors };


### PR DESCRIPTION
- Fix the listbox `.items { min-height: 150px }` issue
- Remove the unneeded popover padding
- Add storybook story to test out the fix for listbox 