### PR TITLE
fix(cosmoz-autocomplete): export part wrap

### DIFF
--- a/src/autocomplete/autocomplete.ts
+++ b/src/autocomplete/autocomplete.ts
@@ -33,7 +33,7 @@ type AProps<I> = Omit<Props<I>, keyof RProps<I>> &
 
 const blank = () => nothing;
 
-const inputParts = ['input', 'control', 'label', 'line', 'error']
+const inputParts = ['input', 'control', 'label', 'line', 'error', 'wrap']
 	.map((part) => `${part}: input-${part}`)
 	.join();
 

--- a/test/__snapshots__/cosmoz-autocomplete.test.snap.js
+++ b/test/__snapshots__/cosmoz-autocomplete.test.snap.js
@@ -5,7 +5,7 @@ snapshots["cosmoz-autocomplete-ui render"] =
 `<cosmoz-input
   always-float-label=""
   autocomplete="off"
-  exportparts="input: input-input,control: input-control,label: input-label,line: input-line,error: input-error"
+  exportparts="input: input-input,control: input-control,label: input-label,line: input-line,error: input-error,wrap: input-wrap"
   id="input"
   part="input"
 >
@@ -58,7 +58,7 @@ snapshots["cosmoz-autocomplete-ui render (limit 1)"] =
   autocomplete="off"
   data-one=""
   data-single=""
-  exportparts="input: input-input,control: input-control,label: input-label,line: input-line,error: input-error"
+  exportparts="input: input-input,control: input-control,label: input-label,line: input-line,error: input-error,wrap: input-wrap"
   id="input"
   part="input"
   readonly=""
@@ -101,7 +101,7 @@ snapshots["cosmoz-autocomplete-ui render (listbox)"] =
 `<cosmoz-input
   always-float-label=""
   autocomplete="off"
-  exportparts="input: input-input,control: input-control,label: input-label,line: input-line,error: input-error"
+  exportparts="input: input-input,control: input-control,label: input-label,line: input-line,error: input-error,wrap: input-wrap"
   id="input"
   part="input"
 >
@@ -137,8 +137,13 @@ snapshots["cosmoz-autocomplete-ui render (listbox)"] =
     </span>
   </cosmoz-autocomplete-chip>
 </cosmoz-input>
-<disconnect-observer>
-</disconnect-observer>
+<cosmoz-listbox
+  multi=""
+  part="listbox"
+  popover="manual"
+  style="left: 8px; top: 68px; min-width: 784px;"
+>
+</cosmoz-listbox>
 `;
 /* end snapshot cosmoz-autocomplete-ui render (listbox) */
 
@@ -146,7 +151,7 @@ snapshots["cosmoz-autocomplete render"] =
 `<cosmoz-input
   always-float-label=""
   autocomplete="off"
-  exportparts="input: input-input,control: input-control,label: input-label,line: input-line,error: input-error"
+  exportparts="input: input-input,control: input-control,label: input-label,line: input-line,error: input-error,wrap: input-wrap"
   id="input"
   part="input"
 >
@@ -188,7 +193,7 @@ snapshots["cosmoz-autocomplete render (deselect)"] =
 `<cosmoz-input
   autocomplete="off"
   data-one=""
-  exportparts="input: input-input,control: input-control,label: input-label,line: input-line,error: input-error"
+  exportparts="input: input-input,control: input-control,label: input-label,line: input-line,error: input-error,wrap: input-wrap"
   id="input"
   part="input"
 >
@@ -216,4 +221,3 @@ snapshots["cosmoz-autocomplete render (deselect)"] =
 </cosmoz-input>
 `;
 /* end snapshot cosmoz-autocomplete render (deselect) */
-


### PR DESCRIPTION
Export input part 'wrap' to prevent autocomplete chip text overflow in cz-accounting.

[AB#11348](https://dev.azure.com/neovici/Cosmoz3/_workitems/edit/11348/)