### PR TITLE
fix: make the sizer take no height

### DIFF
--- a/src/listbox/style.css.ts
+++ b/src/listbox/style.css.ts
@@ -96,7 +96,7 @@ const style = css`
 		border: 2px solid #eee;
 	}
 	[virtualizer-sizer]:not(.sizer) {
-		height: 0;
+		max-height: 2px;
 		overflow: hidden;
 	}
 `;

--- a/src/listbox/style.css.ts
+++ b/src/listbox/style.css.ts
@@ -95,6 +95,10 @@ const style = css`
 		border-radius: 50%;
 		border: 2px solid #eee;
 	}
+	[virtualizer-sizer]:not(.sizer) {
+		height: 0;
+		overflow: hidden;
+	}
 `;
 
 export default style;

--- a/src/listbox/style.css.ts
+++ b/src/listbox/style.css.ts
@@ -96,8 +96,7 @@ const style = css`
 		border: 2px solid #eee;
 	}
 	[virtualizer-sizer]:not(.sizer) {
-		max-height: 2px;
-		overflow: hidden;
+		line-height: 1;
 	}
 `;
 


### PR DESCRIPTION
Fix the vertical scroll to take exactly the height of the items, not more.

Brief explanation: Virtualizer is based on the fact that `virtualizer-sizer` elements have a height of 2px.
When the `virtualizer-sizer` element has a `line-height` greater than 1 it adds the possibility of creating an overflow and then the vertical scroll doesn't match the height of the elements, it's bigger.