### PR TITLE
fix: loader looks bad on very narrow inputs

### DIFF
--- a/src/autocomplete/skeleton-span.ts
+++ b/src/autocomplete/skeleton-span.ts
@@ -10,10 +10,10 @@ const style = css`
 		background-position: right;
 		animation: sweep 1.5s cubic-bezier(0.3, 1, 0.3, 1) infinite;
 		border-radius: 3px;
-		width: calc(100% - 50px);
+		width: calc(100% - 20px);
 		max-width: 150px;
 		height: 20px;
-		margin: 10px 0 10px 33px;
+		margin: 10px;
 	}
 
 	:host-context([show-single]) {


### PR DESCRIPTION
Before:
![Screenshot_2024-11-20_13-57-23](https://github.com/user-attachments/assets/81c0886c-f97e-4d69-904b-557ec45c57b2)

After:
![Screenshot_2024-11-20_13-58-54](https://github.com/user-attachments/assets/6c030e0e-dcc4-44e6-a6ec-11b2e388bdea)

