### PR TITLE
Fix select after query

### DIFF
--- a/src/autocomplete/use-autocomplete.ts
+++ b/src/autocomplete/use-autocomplete.ts
@@ -40,6 +40,7 @@ export interface Props<I> extends Base<I> {
 	disabled?: boolean;
 	onFocus?: (focused?: boolean) => void;
 	preserveOrder?: boolean;
+	defaultIndex?: number;
 }
 
 export const useAutocomplete = <I>({
@@ -57,6 +58,7 @@ export const useAutocomplete = <I>({
 	keepOpened,
 	keepQuery,
 	preserveOrder,
+	defaultIndex,
 	...thru
 }: Props<I>) => {
 	const textual = useMemo(
@@ -178,6 +180,8 @@ export const useAutocomplete = <I>({
 			(val: I | I[]) => meta.onChange(without(val)(meta.value) as I[]),
 			[meta],
 		),
+		// whenever there is a query, override defaultIndex to 0, so the first result gets selected
+		defaultIndex: query?.length > 0 ? 0 : defaultIndex,
 	};
 };
 

--- a/src/listbox/use-items.ts
+++ b/src/listbox/use-items.ts
@@ -24,8 +24,12 @@ export const useItems = <T>({
 		{ length } = items;
 
 	useEffect(() => {
+		// whenever the items list is empty, reset the position to defaultIndex
 		setPosition({
-			index: Math.min(position.index, items.length - 1),
+			index:
+				position.index < 0
+					? defaultIndex
+					: Math.min(position.index, items.length - 1),
 			scroll: true,
 		});
 	}, [items, defaultIndex]);


### PR DESCRIPTION
Whenever there is a query, select the first result.

Fixes AB#17933