### PR TITLE
fix: don't show listbox dropdown when there's no value

### DIFF
--- a/src/listbox/style.css.ts
+++ b/src/listbox/style.css.ts
@@ -38,7 +38,6 @@ const style = css`
 		position: relative;
 		overflow-y: auto;
 		contain: layout paint !important;
-		padding-bottom: var(--cosmoz-autocomplete-listbox-padding-bottom, 8px);
 	}
 	.item {
 		font-size: var(--cosmoz-autocomplete-listbox-font-size, 13px);


### PR DESCRIPTION
Makes sure the dropdown doesn't show up when there's no value. 

Before:
<img width="1857" height="521" alt="Screenshot 2025-08-18 at 17 21 49" src="https://github.com/user-attachments/assets/949cc0c8-68b1-4baa-a51d-20f14991578a" />

After:
<img width="2026" height="493" alt="Screenshot 2025-08-18 at 17 21 54" src="https://github.com/user-attachments/assets/1e7fcdd4-c759-44c9-a06f-54ae4d727f03" />
