### PR TITLE
feat: external-search attribute

### DIFF
--- a/src/autocomplete/autocomplete.ts
+++ b/src/autocomplete/autocomplete.ts
@@ -31,6 +31,7 @@ export interface Props<I> extends Base<I> {
 	itemLimit?: number;
 	wrap?: boolean;
 	defaultIndex?: number;
+	externalSearch?: boolean;
 	placement?: Placement;
 }
 
@@ -184,6 +185,7 @@ const autocomplete = <I>(props: AProps<I>) => {
 		'keep-opened',
 		'keep-query',
 		'default-index',
+		'external-search',
 		'item-height',
 		'item-limit',
 		'wrap',

--- a/src/autocomplete/use-autocomplete.ts
+++ b/src/autocomplete/use-autocomplete.ts
@@ -41,6 +41,7 @@ export interface Props<I> extends Base<I> {
 	onFocus?: (focused?: boolean) => void;
 	preserveOrder?: boolean;
 	defaultIndex?: number;
+	externalSearch?: boolean;
 }
 
 export const useAutocomplete = <I>({
@@ -59,6 +60,7 @@ export const useAutocomplete = <I>({
 	keepQuery,
 	preserveOrder,
 	defaultIndex,
+	externalSearch,
 	...thru
 }: Props<I>) => {
 	const textual = useMemo(
@@ -127,7 +129,7 @@ export const useAutocomplete = <I>({
 				? options
 				: [...value, ...without(value, prop(valueProperty))(options)];
 
-			return search(items, query, textual);
+			return externalSearch ? items : search(items, query, textual);
 		}, [
 			options,
 			active,
@@ -137,6 +139,7 @@ export const useAutocomplete = <I>({
 			value,
 			preserveOrder,
 			valueProperty,
+			externalSearch,
 		]),
 		onClick: useCallback(() => setClosed(false), []),
 		onFocus,


### PR DESCRIPTION
Adds ability to turn off local filtering. Useful when you want to take full control of the filtering via `source`.