### PR TITLE
feat: support for item-height="auto" 

### DIFF
--- a/src/autocomplete/autocomplete.ts
+++ b/src/autocomplete/autocomplete.ts
@@ -27,7 +27,7 @@ export interface Props<I> extends Base<I> {
 	noLabelFloat?: boolean;
 	alwaysFloatLabel?: boolean;
 	showSingle?: boolean;
-	itemHeight?: number;
+	itemHeight?: number | 'auto';
 	itemLimit?: number;
 	wrap?: boolean;
 	defaultIndex?: number;

--- a/src/listbox/index.ts
+++ b/src/listbox/index.ts
@@ -1,23 +1,23 @@
 import {
-	VirtualizeDirectiveConfig,
 	VirtualizerHostElement,
 	virtualize,
 	virtualizerRef,
 } from '@lit-labs/virtualizer/virtualize.js';
+import { connectable } from '@neovici/cosmoz-dropdown/connectable';
 import { sheet } from '@neovici/cosmoz-utils';
 import { spreadProps } from '@neovici/cosmoz-utils/directives/spread-props';
 import { useStyleSheet } from '@neovici/cosmoz-utils/hooks/use-stylesheet';
 import { props } from '@neovici/cosmoz-utils/object';
-import { component, html, useEffect, useMemo, useRef } from '@pionjs/pion';
+import { component, html, useEffect, useRef } from '@pionjs/pion';
 import { ref } from 'lit-html/directives/ref.js';
+import { StyleInfo, styleMap } from 'lit-html/directives/style-map.js';
 import style, { styles } from './style.css';
 import { Props, properties, useListbox } from './use-listbox';
-import { connectable } from '@neovici/cosmoz-dropdown/connectable';
-import { StyleInfo, styleMap } from 'lit-html/directives/style-map.js';
 
 const Listbox = <I>(props: Props<I>) => {
 	const listRef = useRef<Element | undefined>(undefined);
-	const { position, items, renderItem, height, itemHeight } = useListbox(props);
+	const { position, items, renderItem, height, itemHeight, setItemHeight } =
+		useListbox(props);
 
 	useEffect(() => {
 		if (!position.scroll) return;
@@ -25,17 +25,14 @@ const Listbox = <I>(props: Props<I>) => {
 			virtualizerRef
 		];
 		if (!vl?.['_layout']) return;
+		vl.layoutComplete.then(() =>
+			setItemHeight(vl['_layout']._metricsCache.averageChildSize),
+		);
 		vl.element(position.index)?.scrollIntoView({ block: 'nearest' });
 	}, [position]);
 
-	useStyleSheet(styles({ ...position, height, itemHeight }));
-
-	const layout = useMemo(
-		() =>
-			({
-				_itemSize: { height: itemHeight - 0.00001 },
-			}) as VirtualizeDirectiveConfig<unknown>['layout'],
-		[itemHeight],
+	useStyleSheet(
+		styles({ ...position, itemHeight, auto: props.itemHeight === 'auto' }),
 	);
 
 	return html`<div
@@ -48,7 +45,6 @@ const Listbox = <I>(props: Props<I>) => {
 				items,
 				renderItem,
 				scroller: true,
-				layout,
 			})}
 		</div>
 		<slot></slot>`;

--- a/src/listbox/index.ts
+++ b/src/listbox/index.ts
@@ -20,14 +20,21 @@ const Listbox = <I>(props: Props<I>) => {
 		useListbox(props);
 
 	useEffect(() => {
+		const vl = (listRef.current as VirtualizerHostElement | undefined)?.[
+			virtualizerRef
+		];
+		if (!vl) return;
+		vl.layoutComplete.then(() =>
+			setItemHeight(vl['_layout']._metricsCache.averageChildSize),
+		);
+	}, [items]);
+
+	useEffect(() => {
 		if (!position.scroll) return;
 		const vl = (listRef.current as VirtualizerHostElement | undefined)?.[
 			virtualizerRef
 		];
-		if (!vl?.['_layout']) return;
-		vl.layoutComplete.then(() =>
-			setItemHeight(vl['_layout']._metricsCache.averageChildSize),
-		);
+		if (!vl) return;
 		vl.element(position.index)?.scrollIntoView({ block: 'nearest' });
 	}, [position]);
 

--- a/src/listbox/item-renderer.ts
+++ b/src/listbox/item-renderer.ts
@@ -1,8 +1,10 @@
 import { identity } from '@neovici/cosmoz-utils/function';
 import { html, TemplateResult } from 'lit-html';
 import { mark } from './util';
+import { Position } from './use-items';
 
-export interface Opts<I> {
+export interface ItemRendererOpts<I> {
+	position: Position;
 	highlight: (i: number) => void;
 	select: (item: I) => void;
 	isSelected: (item: I) => void;
@@ -15,16 +17,8 @@ export type Render<I> = (content: unknown, item: I, i: number) => unknown;
 export type ItemRenderer<I> = (
 	item: I,
 	i: number,
-	opts: Opts<I>,
+	opts: ItemRendererOpts<I>,
 ) => TemplateResult;
-
-export type ItemRendererOpts<I> = {
-	highlight: (i: number) => void;
-	select: (item: I) => void;
-	isSelected: (item: I) => void;
-	query: string;
-	textual: (i: I) => string;
-};
 
 export const itemRenderer =
 	<I>(render: Render<I> = identity) =>

--- a/src/listbox/item-renderer.ts
+++ b/src/listbox/item-renderer.ts
@@ -42,20 +42,19 @@ export const itemRenderer =
 		const text = textual(item),
 			content = mark(text, query),
 			rendered = render(content, item, i);
-		return html` <div
-				class="item"
-				role="option"
-				part="option"
-				?aria-selected=${isSelected(item)}
-				data-index=${i}
-				@mouseenter=${() => highlight(i)}
-				@click=${() => select(item)}
-				@mousedown=${(e: Event) => e.preventDefault()}
-				title=${text}
-			>
-				${rendered}
-			</div>
-			<div class="sizer" virtualizer-sizer>${rendered}</div>`;
+		return html`<div
+			class="item"
+			role="option"
+			part="option"
+			?aria-selected=${isSelected(item)}
+			data-index=${i}
+			@mouseenter=${() => highlight(i)}
+			@click=${() => select(item)}
+			@mousedown=${(e: Event) => e.preventDefault()}
+			title=${text}
+		>
+			${rendered}
+		</div>`;
 	};
 
 export default itemRenderer();

--- a/src/listbox/item-renderer.ts
+++ b/src/listbox/item-renderer.ts
@@ -18,6 +18,14 @@ export type ItemRenderer<I> = (
 	opts: Opts<I>,
 ) => TemplateResult;
 
+export type ItemRendererOpts<I> = {
+	highlight: (i: number) => void;
+	select: (item: I) => void;
+	isSelected: (item: I) => void;
+	query: string;
+	textual: (i: I) => string;
+};
+
 export const itemRenderer =
 	<I>(render: Render<I> = identity) =>
 	(
@@ -29,13 +37,7 @@ export const itemRenderer =
 			textual = identity as () => string,
 			query,
 			isSelected,
-		}: {
-			highlight: (i: number) => void;
-			select: (item: I) => void;
-			isSelected: (item: I) => void;
-			query: string;
-			textual: (i: I) => string;
-		},
+		}: ItemRendererOpts<I>,
 	): TemplateResult => {
 		const text = textual(item),
 			content = mark(text, query),

--- a/src/listbox/style.css.ts
+++ b/src/listbox/style.css.ts
@@ -99,11 +99,6 @@ export const styles = ({
 	height: number;
 	itemHeight: number;
 }) => css`
-	:host {
-		xmin-height: ${itemHeight}px;
-		xheight: ${height}px;
-	}
-
 	.item {
 		line-height: ${itemHeight}px;
 		height: ${itemHeight}px;

--- a/src/listbox/style.css.ts
+++ b/src/listbox/style.css.ts
@@ -1,4 +1,5 @@
 import { tagged as css } from '@neovici/cosmoz-utils';
+import { when } from 'lit-html/directives/when.js';
 
 const svg =
 	/* eslint-disable quotes */
@@ -11,10 +12,7 @@ const style = css`
 		position: fixed;
 		z-index: 1000;
 		font-family: var(--paper-font-subhead_-_font-family, inherit);
-		background: var(
-			--cosmoz-autocomplete-listbox-bg,
-			rgba(255, 255, 255, 0.2)
-		);
+		background: var(--cosmoz-autocomplete-listbox-bg, rgba(255, 255, 255, 0.2));
 		min-width: 50px;
 		backdrop-filter: blur(16px) saturate(180%);
 		-webkit-backdrop-filter: blur(16px) saturate(180%);
@@ -92,17 +90,22 @@ export default style;
 
 export const styles = ({
 	index,
-	height,
 	itemHeight,
+	auto
 }: {
 	index?: number;
-	height: number;
 	itemHeight: number;
+	auto: boolean;
 }) => css`
-	.item {
-		line-height: ${itemHeight}px;
-		height: ${itemHeight}px;
-	}
+	${when(
+		!auto,
+		() => css`
+			.item {
+				line-height: ${itemHeight}px;
+				height: ${itemHeight}px;
+			}
+		`,
+	)}
 
 	.item[data-index='${index || '0'}'] {
 		background: var(

--- a/src/listbox/style.css.ts
+++ b/src/listbox/style.css.ts
@@ -53,20 +53,6 @@ const style = css`
 		overflow: hidden;
 	}
 
-	.sizer {
-		position: relative;
-		visibility: hidden;
-		opacity: 0;
-		pointer-events: none;
-		z-index: -1;
-		height: 0;
-		width: auto;
-		padding: 0 20px;
-		overflow: hidden;
-		max-width: inherit;
-		font-size: 14px;
-	}
-
 	:host(:not([multi])) .item[aria-selected] {
 		background: var(--cosmoz-listbox-single-selection-color, #dadada);
 	}
@@ -89,9 +75,6 @@ const style = css`
 		/* prettier-ignore */
 		background: url("${svg}") #5881f6 no-repeat 50%;
 	}
-	:host([multi]) .sizer {
-		padding-left: 33px;
-	}
 	.swatch {
 		width: 18px;
 		height: 18px;
@@ -100,7 +83,7 @@ const style = css`
 		vertical-align: middle;
 		border-radius: 50%;
 	}
-	[virtualizer-sizer]:not(.sizer) {
+	[virtualizer-sizer] {
 		line-height: 1;
 	}
 `;

--- a/src/listbox/use-item-height.ts
+++ b/src/listbox/use-item-height.ts
@@ -1,0 +1,11 @@
+import { useState } from '@pionjs/pion';
+
+export const useItemHeight = (initialItemHeight: number | 'auto') => {
+	const auto = initialItemHeight === 'auto',
+		[itemHeight, setItemHeight] = useState(auto ? 40 : initialItemHeight);
+
+	return [
+		itemHeight,
+		(v: number) => (auto ? setItemHeight(v) : undefined),
+	] as const;
+};

--- a/src/listbox/use-listbox.ts
+++ b/src/listbox/use-listbox.ts
@@ -69,6 +69,7 @@ export const useListbox = <I>({
 		setItemHeight,
 		renderItem: useRenderItem({
 			itemRenderer,
+			position,
 			highlight,
 			select,
 			textual,

--- a/src/listbox/use-listbox.ts
+++ b/src/listbox/use-listbox.ts
@@ -2,6 +2,7 @@ import { useMemo } from '@pionjs/pion';
 import { byValue } from './util';
 import { useItems } from './use-items';
 import { useRenderItem, ItemRenderer } from './use-render-item';
+import { useItemHeight } from './use-item-height';
 
 export const properties = [
 	'query',
@@ -27,7 +28,7 @@ export interface Props<I> {
 	query: string;
 	textual: (i: I) => string;
 	itemRenderer?: ItemRenderer<I>;
-	itemHeight?: number;
+	itemHeight?: number | 'auto';
 	itemLimit?: number;
 }
 
@@ -40,7 +41,7 @@ export const useListbox = <I>({
 	query,
 	textual,
 	itemRenderer,
-	itemHeight = 40,
+	itemHeight: _itemHeight = 40,
 	itemLimit = 5,
 }: Props<I>) => {
 	const isSelected = useMemo(
@@ -55,7 +56,8 @@ export const useListbox = <I>({
 			defaultIndex: isNaN(defaultIndex as number)
 				? undefined
 				: Number(defaultIndex),
-		});
+		}),
+		[itemHeight, setItemHeight] = useItemHeight(_itemHeight);
 
 	return {
 		position,
@@ -64,6 +66,7 @@ export const useListbox = <I>({
 		highlight,
 		select,
 		itemHeight,
+		setItemHeight,
 		renderItem: useRenderItem({
 			itemRenderer,
 			highlight,

--- a/src/listbox/use-render-item.ts
+++ b/src/listbox/use-render-item.ts
@@ -3,14 +3,14 @@ import { useMeta } from '@neovici/cosmoz-utils/hooks/use-meta';
 import {
 	itemRenderer as mkItemRenderer,
 	ItemRenderer,
-	Opts,
+	ItemRendererOpts,
 } from './item-renderer';
 
 export const useRenderItem = <I>({
 	itemRenderer = mkItemRenderer<I>(),
 	...meta
-}: Opts<I> & { itemRenderer?: ItemRenderer<I> }) => {
-	const info = useMeta<Opts<I>>(meta);
+}: ItemRendererOpts<I> & { itemRenderer?: ItemRenderer<I> }) => {
+	const info = useMeta<ItemRendererOpts<I>>(meta);
 	return useCallback(
 		(item: I, i: number) => itemRenderer(item, i, info),
 		[info, itemRenderer],

--- a/test/cosmoz-listbox.test.js
+++ b/test/cosmoz-listbox.test.js
@@ -4,7 +4,7 @@ import '../src/listbox';
 import { spy } from 'sinon';
 
 const ready = async (el) => {
-	await oneEvent(el.shadowRoot.querySelector('.items'), 'rangeChanged');
+	await oneEvent(el, 'layout-complete');
 	await nextFrame();
 };
 


### PR DESCRIPTION
When `itemHeight` is set to `'auto'`, it will let the virtualizer calculate the height of the children. Useful when you have a custom item renderer with variable height.

Also did some cleanup, more details in the commit log.