### PR TITLE
fix: items are not rendered fully

### DIFF
--- a/src/listbox/item-renderer.ts
+++ b/src/listbox/item-renderer.ts
@@ -37,18 +37,19 @@ export const itemRenderer =
 			content = mark(text, query),
 			rendered = render(content, item, i);
 		return html`<div
-			class="item"
-			role="option"
-			part="option"
-			?aria-selected=${isSelected(item)}
-			data-index=${i}
-			@mouseenter=${() => highlight(i)}
-			@click=${() => select(item)}
-			@mousedown=${(e: Event) => e.preventDefault()}
-			title=${text}
-		>
-			${rendered}
-		</div>`;
+				class="item"
+				role="option"
+				part="option"
+				?aria-selected=${isSelected(item)}
+				data-index=${i}
+				@mouseenter=${() => highlight(i)}
+				@click=${() => select(item)}
+				@mousedown=${(e: Event) => e.preventDefault()}
+				title=${text}
+			>
+				${rendered}
+			</div>
+			<div class="sizer" virtualizer-sizer>${rendered}</div>`;
 	};
 
 export default itemRenderer();

--- a/src/listbox/style.css.ts
+++ b/src/listbox/style.css.ts
@@ -51,6 +51,20 @@ const style = css`
 		overflow: hidden;
 	}
 
+	.sizer {
+		position: relative;
+		visibility: hidden;
+		opacity: 0;
+		pointer-events: none;
+		z-index: -1;
+		height: 0;
+		width: auto;
+		padding: 0 20px;
+		overflow: hidden;
+		max-width: inherit;
+		font-size: 14px;
+	}
+
 	:host(:not([multi])) .item[aria-selected] {
 		background: var(--cosmoz-listbox-single-selection-color, #dadada);
 	}
@@ -73,6 +87,9 @@ const style = css`
 		/* prettier-ignore */
 		background: url("${svg}") #5881f6 no-repeat 50%;
 	}
+	:host([multi]) .sizer {
+		padding-left: 33px;
+	}
 	.swatch {
 		width: 18px;
 		height: 18px;
@@ -81,7 +98,7 @@ const style = css`
 		vertical-align: middle;
 		border-radius: 50%;
 	}
-	[virtualizer-sizer] {
+	[virtualizer-sizer]:not(.sizer) {
 		line-height: 1;
 	}
 `;


### PR DESCRIPTION
This reverts commit 8e25878c408dd44253da3e87b65fc2fa821ffcc5.

The removal caused a bug where the options are not rendered full-width.