### PR TITLE
fix: margin is not taken into account when item-size="auto"

### DIFF
--- a/src/listbox/index.ts
+++ b/src/listbox/index.ts
@@ -29,7 +29,9 @@ const Listbox = <I>(host: HTMLElement & Props<I>) => {
 		if (!vl) return;
 		vl.layoutComplete.then(() => {
 			host.dispatchEvent(new CustomEvent('layout-complete'));
-			return setItemHeight(vl['_layout']._metricsCache.averageChildSize);
+			const { averageChildSize, averageMarginSize } =
+				vl['_layout']._metricsCache;
+			return setItemHeight(averageChildSize + averageMarginSize * 2);
 		}, ignore);
 	}, [items]);
 


### PR DESCRIPTION
Adding margin to custom results makes the scrollbar show when it shouldn't.