### PR TITLE
feat: replace chip overflow detection with IntersectionObserver

### DIFF
--- a/src/autocomplete/autocomplete.ts
+++ b/src/autocomplete/autocomplete.ts
@@ -33,6 +33,7 @@ export interface Props<I> extends Base<I> {
 type AProps<I> = Omit<Props<I>, keyof RProps<I>> &
 	RProps<I> & {
 		onInputRef?: (el?: Element) => void;
+		overflowCount?: number;
 	};
 
 const inputParts = ['input', 'control', 'label', 'line', 'error', 'wrap']
@@ -76,6 +77,7 @@ const autocomplete = <I>(props: AProps<I>) => {
 				source$,
 				loading,
 				chipRenderer,
+				overflowCount = 0,
 			} = props,
 			isOne = limit == 1, // eslint-disable-line eqeqeq
 			isSingle = isOne && value?.[0] != null;
@@ -130,6 +132,17 @@ const autocomplete = <I>(props: AProps<I>) => {
 					disabled,
 					chipRenderer,
 				})}
+				${when(
+					overflowCount > 0,
+					() =>
+						html`<cosmoz-autocomplete-chip
+							class="badge"
+							slot="control"
+							part="chip badge"
+						>
+							+${overflowCount}
+						</cosmoz-autocomplete-chip>`,
+				)}
 			</cosmoz-input>
 
 			${when(
@@ -168,8 +181,8 @@ const autocomplete = <I>(props: AProps<I>) => {
 			...props,
 			...useAutocomplete(props),
 		};
-		useOverflow(thru);
-		return autocomplete(thru);
+		const { overflowCount } = useOverflow(thru);
+		return autocomplete({ ...thru, overflowCount });
 	},
 	observedAttributes = [
 		'disabled',

--- a/src/autocomplete/chip.ts
+++ b/src/autocomplete/chip.ts
@@ -62,13 +62,11 @@ export interface ChipProps<I> extends Props {
 	slot?: string;
 	className?: string;
 	content: unknown;
-	hidden?: boolean;
 }
 export const chip = <I>({
 	content,
 	onClear,
 	disabled,
-	hidden,
 	className = 'chip',
 	slot,
 }: ChipProps<I>) =>
@@ -78,7 +76,6 @@ export const chip = <I>({
 		part="chip"
 		exportparts="chip-text, chip-clear"
 		?disabled=${disabled}
-		?hidden=${hidden}
 		.onClear=${onClear}
 		title=${ifDefined(typeof content === 'string' ? content : undefined)}
 		>${content}</cosmoz-autocomplete-chip

--- a/src/autocomplete/selection.ts
+++ b/src/autocomplete/selection.ts
@@ -1,4 +1,3 @@
-import { html } from 'lit-html';
 import { chip as defaultChipRenderer } from './chip';
 import type { RProps } from './use-autocomplete';
 
@@ -23,8 +22,8 @@ export const selection = <I>({
 	textual,
 	disabled,
 	chipRenderer = defaultChipRenderer,
-}: Props<I>) => [
-	...values.filter(Boolean).map((value) =>
+}: Props<I>) =>
+	values.filter(Boolean).map((value) =>
 		chipRenderer({
 			item: value,
 			content: textual(value),
@@ -32,13 +31,4 @@ export const selection = <I>({
 			disabled,
 			slot: 'control',
 		}),
-	),
-	chipRenderer({
-		item: null,
-		content: html`<span></span>`,
-		className: 'badge',
-		disabled: true,
-		slot: 'control',
-		hidden: true,
-	}),
-];
+	);

--- a/src/autocomplete/styles.css.ts
+++ b/src/autocomplete/styles.css.ts
@@ -20,6 +20,8 @@ export default css`
 		flex-wrap: wrap;
 		gap: 4px;
 		min-width: 35px;
+	}
+	cosmoz-input:not([data-one])::part(control) {
 		overflow: hidden;
 		max-height: calc(var(--cosmoz-autocomplete-chip-row-height) + 2px + 4px);
 	}

--- a/src/autocomplete/styles.css.ts
+++ b/src/autocomplete/styles.css.ts
@@ -20,9 +20,6 @@ export default css`
 		flex-wrap: wrap;
 		gap: 4px;
 		min-width: 35px;
-	}
-	cosmoz-input:not([data-one])::part(control) {
-		overflow: hidden;
 		max-height: calc(var(--cosmoz-autocomplete-chip-row-height) + 2px + 4px);
 	}
 	cosmoz-input::part(input) {
@@ -57,9 +54,7 @@ export default css`
 	}
 
 	:host([wrap]) cosmoz-input::part(control) {
-		flex-wrap: wrap;
 		max-height: none;
-		overflow: visible;
 	}
 	:host([wrap]) .chip {
 		max-width: 100%;

--- a/src/autocomplete/styles.css.ts
+++ b/src/autocomplete/styles.css.ts
@@ -5,6 +5,10 @@ export default css`
 		display: block;
 		position: relative;
 		min-width: 35px;
+		--cosmoz-autocomplete-chip-row-height: var(
+			--cosmoz-autocomplete-chip-text-line-height,
+			22px
+		);
 	}
 
 	cosmoz-dropdown-next {
@@ -13,8 +17,11 @@ export default css`
 
 	cosmoz-input::part(control) {
 		display: flex;
+		flex-wrap: wrap;
 		gap: 4px;
 		min-width: 35px;
+		overflow: hidden;
+		max-height: calc(var(--cosmoz-autocomplete-chip-row-height) + 2px + 4px);
 	}
 	cosmoz-input::part(input) {
 		flex: 1 24px;
@@ -49,6 +56,8 @@ export default css`
 
 	:host([wrap]) cosmoz-input::part(control) {
 		flex-wrap: wrap;
+		max-height: none;
+		overflow: visible;
 	}
 	:host([wrap]) .chip {
 		max-width: 100%;

--- a/src/autocomplete/use-overflow.ts
+++ b/src/autocomplete/use-overflow.ts
@@ -1,41 +1,118 @@
 import { useHost } from '@neovici/cosmoz-utils/hooks/use-host';
-import { useLayoutEffect, useMemo, useState } from '@pionjs/pion';
-import { raf } from './util';
+import { useEffect, useState } from '@pionjs/pion';
 
-// eslint-disable-next-line max-statements
-const overflow = (host: HTMLElement) => {
-	const chips = host.shadowRoot!.querySelectorAll<HTMLElement>('.chip');
-	const badge = host.shadowRoot!.querySelector<HTMLElement>('.badge')!;
-	badge.hidden = true;
-	for (const chip of chips) {
-		chip.hidden = false;
+/**
+ * Determines overflow in the chip container using IntersectionObserver.
+ *
+ * Two-phase approach:
+ *   1. **Detect**: unhide all chips, observe them with IO against the control
+ *      container. Once every chip has reported, classify visible vs overflowing.
+ *   2. **Settle**: hide overflowing chips (so the badge fits on row 1) and
+ *      update the overflow count. IO callbacks for newly-hidden elements are
+ *      ignored (they have height 0 and are expected).
+ *
+ * Resets on `slotchange` (chips added / removed via lit-html re-render).
+ */
+
+const isChip = (el: Element): el is HTMLElement =>
+	el.tagName === 'COSMOZ-AUTOCOMPLETE-CHIP' && !el.classList.contains('badge');
+
+const classifyEntry = (entry: IntersectionObserverEntry) => {
+	if (
+		entry.intersectionRect.height > 0 &&
+		entry.boundingClientRect.width === entry.intersectionRect.width
+	) {
+		return 'visible';
 	}
-	const input = host.shadowRoot!.querySelector('cosmoz-input')!;
-	const limit = input.shadowRoot
-		?.querySelector('.control')
-		?.getBoundingClientRect();
-	let i;
-	for (i = 0; i < chips.length; i++) {
-		const chip = chips[i];
-		const bounds = chip.getBoundingClientRect();
-		const isIn = bounds.x + bounds.width <= limit!.x + limit!.width - 24;
-		if (!isIn) {
-			break;
+	if (entry.boundingClientRect.height > 0) return 'overflowing';
+	return 'hidden';
+};
+
+const classifyEntries = (
+	entries: IntersectionObserverEntry[],
+	pending: Set<HTMLElement>,
+) => {
+	const overflowing: HTMLElement[] = [];
+	for (const entry of entries) {
+		const el = entry.target as HTMLElement;
+		pending.delete(el);
+		if (classifyEntry(entry) === 'overflowing') overflowing.push(el);
+	}
+	return overflowing;
+};
+
+const setupChipOverflow = (
+	root: HTMLElement,
+	slot: HTMLSlotElement,
+	onCount: (count: number) => void,
+): (() => void) => {
+	let settled = false;
+	const pending = new Set<HTMLElement>();
+	let hiddenChips: HTMLElement[] = [];
+
+	const observer = new IntersectionObserver(
+		(entries) => {
+			if (settled) return;
+
+			const overflowing = classifyEntries(entries, pending);
+
+			// Only settle once all pending chips have reported
+			if (pending.size > 0) return;
+
+			// Settle: hide overflowing chips to make room for the badge
+			settled = true;
+			hiddenChips = overflowing;
+			for (const el of hiddenChips) {
+				el.hidden = true;
+				observer.unobserve(el);
+			}
+
+			onCount(hiddenChips.length);
+		},
+		{ root, threshold: [0, 1] },
+	);
+
+	const reset = () => {
+		// Unhide previously hidden chips
+		for (const el of hiddenChips) {
+			el.hidden = false;
 		}
-	}
+		hiddenChips = [];
+		settled = false;
+		pending.clear();
+		observer.disconnect();
 
-	const overflown = chips.length - i;
-	badge.querySelector('span')!.textContent = '+' + overflown.toString();
-	badge.hidden = overflown < 1;
+		// Observe all current chip elements
+		const chips = slot.assignedElements({ flatten: true }).filter(isChip);
 
-	for (; i < chips.length; i++) {
-		chips[i].hidden = true;
-	}
+		if (chips.length === 0) {
+			onCount(0);
+			return;
+		}
+
+		for (const chip of chips) {
+			pending.add(chip);
+			observer.observe(chip);
+		}
+	};
+
+	// Initial run
+	reset();
+
+	// Re-run when chips change (lit-html re-renders the selection)
+	slot.addEventListener('slotchange', reset);
+
+	return () => {
+		slot.removeEventListener('slotchange', reset);
+		observer.disconnect();
+		// Unhide on cleanup
+		for (const el of hiddenChips) {
+			el.hidden = false;
+		}
+	};
 };
 
 export const useOverflow = <I>({
-	value,
-	opened,
 	wrap,
 	limit,
 }: {
@@ -47,21 +124,39 @@ export const useOverflow = <I>({
 	const host = useHost();
 	// eslint-disable-next-line eqeqeq
 	const enabled = !(wrap || limit == 1);
-	const doRaf = useMemo(() => raf(() => overflow(host)), []);
-	const [width, setWidth] = useState(0);
+	const [overflowCount, setOverflowCount] = useState(0);
 
-	useLayoutEffect(() => {
-		if (!enabled) return;
-		const input = host.shadowRoot!.querySelector('cosmoz-input')!;
-		const observer = new ResizeObserver((e) => {
-			setWidth(e[0].contentRect.width);
+	useEffect(() => {
+		if (!enabled) {
+			setOverflowCount(0);
+			return;
+		}
+
+		let cleanup: (() => void) | undefined;
+		let cancelled = false;
+
+		// Defer slot lookup to next animation frame so cosmoz-input's
+		// shadow DOM has rendered its template (it's a Pion component
+		// whose render is scheduled as a microtask).
+		const raf = requestAnimationFrame(() => {
+			if (cancelled) return;
+
+			const input = host.shadowRoot!.querySelector('cosmoz-input')!;
+			const control = input?.shadowRoot?.querySelector<HTMLElement>('.control');
+			const slot = input?.shadowRoot?.querySelector<HTMLSlotElement>(
+				'slot[name="control"]',
+			);
+			if (!control || !slot) return;
+
+			cleanup = setupChipOverflow(control, slot, setOverflowCount);
 		});
-		observer.observe(input);
-		return () => observer.disconnect();
+
+		return () => {
+			cancelled = true;
+			cancelAnimationFrame(raf);
+			cleanup?.();
+		};
 	}, [enabled]);
 
-	useLayoutEffect(
-		() => (enabled ? doRaf() : undefined),
-		[enabled, width, opened, value],
-	);
+	return { overflowCount: enabled ? overflowCount : 0 };
 };

--- a/src/autocomplete/util.ts
+++ b/src/autocomplete/util.ts
@@ -56,24 +56,3 @@ export const notify = <T>(host: EventTarget, name: string, detail: T) =>
 	host.dispatchEvent(new CustomEvent(name, { detail }));
 
 export const EMPTY: never[] = [];
-
-type Arr = unknown[];
-type ArrFn<T extends Arr> = (...args: T) => void;
-
-/**
- * Request animation frame wrapper with cleanup.
- */
-export const raf =
-	<A extends Arr, F extends ArrFn<A> = ArrFn<A>>(fn: F) =>
-	(...args: A) => {
-		let id: number | undefined;
-		const cleanup = () => {
-			if (id) cancelAnimationFrame(id);
-		};
-		cleanup();
-		id = requestAnimationFrame(() => {
-			id = undefined;
-			fn(...args);
-		});
-		return cleanup;
-	};

--- a/src/excluding/index.ts
+++ b/src/excluding/index.ts
@@ -55,14 +55,7 @@ const mkItemRenderer =
 
 const mkChipRenderer =
 	<I>(value: WrappedItem<I>[] | undefined, onClear: (item: I | null) => void) =>
-	({
-		item,
-		content,
-		disabled,
-		hidden,
-		className = 'chip',
-		slot,
-	}: ChipProps<I>) =>
+	({ item, content, disabled, className = 'chip', slot }: ChipProps<I>) =>
 		html`<cosmoz-autocomplete-chip
 			class=${ifDefined(className)}
 			slot=${ifDefined(slot)}
@@ -70,7 +63,6 @@ const mkChipRenderer =
 			exportparts="chip-text, chip-clear"
 			data-state=${excludedState(value, item)}
 			?disabled=${disabled}
-			?hidden=${hidden}
 			.onClear=${() => onClear(item)}
 			title=${ifDefined(typeof content === 'string' ? content : undefined)}
 		>


### PR DESCRIPTION
## Summary

- Replace the old `ResizeObserver` + `getBoundingClientRect` + `requestAnimationFrame` chip overflow mechanism with a two-phase `IntersectionObserver` approach
- Badge is now rendered separately in `autocomplete.ts` driven by reactive `overflowCount` state, instead of being injected into the selection chip array
- Chips are constrained to one row via `flex-wrap: wrap` + `overflow: hidden` + `max-height` on the `.control` part; IO detects wrapped-out chips and hides them imperatively to free space for the badge

## Changes

- **`use-overflow.ts`** — Complete rewrite. `setupChipOverflow()` creates an IO against cosmoz-input's `.control` div (via shadow DOM part query), observes slotted chips, classifies entries as visible/overflowing, hides overflowing chips imperatively, and returns `overflowCount` via state
- **`autocomplete.ts`** — Badge rendered via `when(overflowCount > 0, ...)` with `slot="control"`, `useOverflow` returns `{ overflowCount }`
- **`selection.ts`** — Removed badge chip from selection array; simplified to plain `.map()`
- **`chip.ts`** — Removed `hidden` prop from `ChipProps`
- **`styles.css.ts`** — Added CSS custom property `--cosmoz-autocomplete-chip-row-height`, flex-wrap + overflow constraints, `:host([wrap])` overrides
- **`util.ts`** — Removed unused `raf` helper
- **`excluding/index.ts`** — Removed `hidden` from chip renderer

## Testing

- All 45 Storybook tests pass
- All 5 Playwright E2E tests pass
- TypeScript compiles clean, lint passes
- Visually verified: Overflown story (badge appears), Wrap story (multi-row, no badge), Basic story (no overflow), Single story (limit=1)