### PR TITLE
fix: correct i18next range to >=23.0.0 <27.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@neovici/cosmoz-input": "^5.6.0",
 				"@neovici/cosmoz-utils": "^6.20.0",
 				"@pionjs/pion": "^2.7.1",
-				"i18next": "^26.0.10",
+				"i18next": ">=23.0.0 <27.0.0",
 				"lit-html": "^2.0.0 || ^3.0.0"
 			},
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 		"@neovici/cosmoz-input": "^5.6.0",
 		"@neovici/cosmoz-utils": "^6.20.0",
 		"@pionjs/pion": "^2.7.1",
-		"i18next": "^26.0.10",
+		"i18next": ">=23.0.0 <27.0.0",
 		"lit-html": "^2.0.0 || ^3.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary

The previous PR #246 incorrectly set `i18next` to `^26.0.10` instead of `>=23.0.0 <27.0.0`. This was caused by `npm install` overwriting the range specifier in package.json.

This PR corrects the range:

```diff
-   "i18next": "^26.0.10",
+   "i18next": ">=23.0.0 <27.0.0",
```

This is a non-breaking range expansion — v23.x is still accepted, while also allowing v25.x and v26.x.

Resolves FE-615