### PR TITLE
fix: skip resize observer and reflow when no value selected

### DIFF
--- a/src/autocomplete/use-overflow.ts
+++ b/src/autocomplete/use-overflow.ts
@@ -5,6 +5,7 @@ import { raf } from './util';
 // eslint-disable-next-line max-statements
 const overflow = (host: HTMLElement) => {
 	const chips = host.shadowRoot!.querySelectorAll<HTMLElement>('.chip');
+	if (chips.length === 0) return;
 	const badge = host.shadowRoot!.querySelector<HTMLElement>('.badge');
 	if (!badge) return;
 	badge.hidden = true;
@@ -46,7 +47,7 @@ export const useOverflow = <I>({
 	limit?: number;
 }) => {
 	const host = useHost();
-	const enabled = !(wrap || limit === 1);
+	const enabled = !(wrap || limit === 1) && value.length > 0;
 	const doRaf = useMemo(() => raf(() => overflow(host)), []);
 	const [width, setWidth] = useState(0);
 


### PR DESCRIPTION
## Problem

When no value is selected, `useOverflow` still:
- Runs a `ResizeObserver` on the input element
- Calls `requestAnimationFrame` on every resize tick
- Executes `overflow()` which calls `getBoundingClientRect()` on `.chip`, `.badge`, and `.control` elements

With zero chips, this is pure waste — forced layout recalculation on every resize event.

## Solution

Two changes to `src/autocomplete/use-overflow.ts`:

1. **Disable the ResizeObserver when `value.length === 0`** — the overflow logic only matters when there are chips to overflow. When value is empty, there's nothing to compute.

2. **Early exit in `overflow()` when no chips exist** — safety net for edge cases where `value` contains falsy items that get filtered by `selection()`, leaving 0 actual chip elements.

## Safety

- **Value transitions are handled correctly**: when `value` goes from empty to non-empty, `enabled` flips, the `useLayoutEffect` creates the observer, and the second `useLayoutEffect` fires `doRaf()` to run overflow immediately.
- **Badge is already hidden by default** (`selection.ts` renders with `hidden: true`), so skipping overflow produces the same visual result.
- **No behavior change** for the non-empty value case.