### PR TITLE
fix: skip resize observer and reflow when no value selected

### DIFF
--- a/src/autocomplete/use-overflow.ts
+++ b/src/autocomplete/use-overflow.ts
@@ -45,7 +45,7 @@ export const useOverflow = <I>({
 	limit?: number;
 }) => {
 	const host = useHost();
-	const enabled = !(wrap || limit === 1);
+	const enabled = !(wrap || limit === 1) && value.length > 0;
 	const doRaf = useMemo(() => raf(() => overflow(host)), []);
 	const [width, setWidth] = useState(0);
 


### PR DESCRIPTION
## Problem

When no value is selected, `useOverflow` still runs a `ResizeObserver` on the input element, schedules `requestAnimationFrame` on every resize tick, and calls `getBoundingClientRect()` on `.chip`, `.badge`, and `.control` elements.

With zero chips, this is pure waste — forced layout recalculation on every resize event.

## Solution

Single line change — disable the ResizeObserver when `value.length === 0`. The overflow logic only matters when there are chips to overflow.

## Safety

- **Value transitions are handled correctly**: when `value` goes from empty to non-empty, `enabled` flips, the `useLayoutEffect` creates the observer, and the second `useLayoutEffect` fires `doRaf()` to run overflow immediately.
- **Badge is already hidden by default** (`selection.ts` renders with `hidden: true`), so skipping overflow produces the same visual result.
- **No behavior change** for the non-empty value case.