### PR TITLE
feat: unwrap value to single item in select mode

### DIFF
--- a/src/autocomplete/index.ts
+++ b/src/autocomplete/index.ts
@@ -24,10 +24,10 @@ const Standalone = <I>(host: HTMLElement & Props<I>) => {
 		value,
 		onChange: useCallback(
 			(value: I[], ...args) => {
-				setValue(value);
+				setValue(isSelect ? value[0] : value);
 				onChange?.(value, ...args);
 			},
-			[onChange],
+			[onChange, isSelect],
 		),
 		onText: useCallback(
 			(text: string) => {

--- a/src/autocomplete/use-autocomplete.ts
+++ b/src/autocomplete/use-autocomplete.ts
@@ -61,6 +61,7 @@ export interface Props<I> extends Base<I> {
 	textProperty?: string;
 	textual?: (prop?: string) => (i: I) => string;
 	valueProperty?: string;
+	mode?: 'select';
 	disabled?: boolean;
 	preserveOrder?: boolean;
 	defaultIndex?: number;
@@ -71,6 +72,7 @@ export interface Props<I> extends Base<I> {
 export const useAutocomplete = <I>({
 	value: _value,
 	text,
+	mode,
 	onChange: _onChange,
 	onText: _onText,
 	onSelect,
@@ -90,6 +92,7 @@ export const useAutocomplete = <I>({
 }: Props<I>) => {
 	const limit = _limit != null ? Number(_limit) : undefined,
 		min = _min != null ? Number(_min) : undefined,
+		isSelect = mode === 'select',
 		textual = useMemo(
 			() => (_textual ?? strProp)(textProperty),
 			[_textual, textProperty],
@@ -102,7 +105,9 @@ export const useAutocomplete = <I>({
 		onChange = useCallback(
 			(val: I[]) => {
 				_onChange?.(val, () => setOpened(false));
-				notify(host, 'value', val);
+				const detail = isSelect ? val[0] : val;
+
+				notify(host, 'value', detail);
 			},
 			[_onChange],
 		),

--- a/stories/tests/autocomplete.stories.ts
+++ b/stories/tests/autocomplete.stories.ts
@@ -25,6 +25,7 @@ interface AutocompleteArgs {
 	lazyOpen?: boolean;
 	preserveOrder?: boolean;
 	required?: boolean;
+	mode?: 'select';
 }
 
 const AutocompleteTest = ({
@@ -44,6 +45,7 @@ const AutocompleteTest = ({
 	lazyOpen,
 	preserveOrder,
 	required,
+	mode,
 }: AutocompleteArgs): TemplateResult => html`
 	<cosmoz-autocomplete
 		.source=${source}
@@ -62,6 +64,7 @@ const AutocompleteTest = ({
 		?keep-opened=${keepOpened}
 		?external-search=${externalSearch}
 		?preserve-order=${preserveOrder}
+		.mode=${mode}
 	></cosmoz-autocomplete>
 `;
 
@@ -685,5 +688,63 @@ export const Required: Story = {
 
 		const input = await canvas.findByShadowRole('textbox');
 		expect(input.hasAttribute('required')).toBe(true);
+	},
+};
+
+export const SelectModeValueIsSingleItem: Story = {
+	args: {
+		source: colors,
+		mode: 'select',
+		onChange: fn(),
+	},
+	play: async ({ canvas, canvasElement, args }) => {
+		const input = await canvas.findByShadowRole('textbox');
+		await userEvent.click(input);
+
+		const option = await canvas.findByShadowRole('option', { name: /Red/u });
+		await userEvent.click(option);
+
+		await waitFor(() => {
+			expect(args.onChange).toHaveBeenCalledWith(
+				[colors[0]],
+				expect.any(Function),
+			);
+		});
+
+		const autocomplete = canvasElement.querySelector<
+			HTMLElement & { value: unknown }
+		>('cosmoz-autocomplete')!;
+		const { value } = autocomplete;
+		expect(Array.isArray(value)).toBe(false);
+		expect(value).toEqual(colors[0]);
+	},
+};
+
+export const MultiModeValueIsArray: Story = {
+	args: {
+		source: colors,
+		limit: 1,
+		onChange: fn(),
+	},
+	play: async ({ canvas, canvasElement, args }) => {
+		const input = await canvas.findByShadowRole('textbox');
+		await userEvent.click(input);
+
+		const option = await canvas.findByShadowRole('option', { name: /Red/u });
+		await userEvent.click(option);
+
+		await waitFor(() => {
+			expect(args.onChange).toHaveBeenCalledWith(
+				[colors[0]],
+				expect.any(Function),
+			);
+		});
+
+		const autocomplete = canvasElement.querySelector<
+			HTMLElement & { value: unknown }
+		>('cosmoz-autocomplete')!;
+		const { value } = autocomplete;
+		expect(Array.isArray(value)).toBe(true);
+		expect(value).toEqual([colors[0]]);
 	},
 };


### PR DESCRIPTION
When `mode='select'` is used, the autocomplete should behave like a native `<select>` element, returning a single value instead of an array.

Previously, the Standalone wrapper's `onChange` always called `setValue(value)` with `I[]`, even in select mode. This meant that after selecting an item, the element's value property was [item] instead of item, breaking form integrations that expect a plain value.

When `mode='select'`, cosmoz-autocomplete now emits a single value instead of an array through both the host property and custom event, matching the single-select semantics.

