### PR TITLE
chore(deps-dev): bump @playwright/test to 1.60.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"@commitlint/cli": "^20.0.0",
 				"@commitlint/config-conventional": "^20.0.0",
 				"@neovici/cfg": "^2.8.0",
-				"@playwright/test": "^1.43.1",
+				"@playwright/test": "^1.60.0",
 				"@semantic-release/changelog": "^6.0.0",
 				"@semantic-release/git": "^10.0.0",
 				"@storybook/addon-docs": "^10.0.0",
@@ -1674,13 +1674,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.58.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
-			"integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+			"integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.58.0"
+				"playwright": "1.61.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -14711,13 +14711,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.58.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
-			"integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+			"integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.58.0"
+				"playwright-core": "1.61.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -14730,9 +14730,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.58.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
-			"integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
 		"@commitlint/cli": "^20.0.0",
 		"@commitlint/config-conventional": "^20.0.0",
 		"@neovici/cfg": "^2.8.0",
-		"@playwright/test": "^1.43.1",
+		"@playwright/test": "^1.60.0",
 		"@semantic-release/changelog": "^6.0.0",
 		"@semantic-release/git": "^10.0.0",
 		"@storybook/addon-docs": "^10.0.0",


### PR DESCRIPTION
Bump Playwright test dependency to version 1.60.0 to fix CI runner issues.

This is a prerequisite for the changeset migration (FE-694).